### PR TITLE
TJW-239: Back up sure.am Postgres in Borg nightly dump.

### DIFF
--- a/borg/README.md
+++ b/borg/README.md
@@ -59,6 +59,7 @@ If replication fails mid-transfer, simply run `./main.sh --replicate-only` to re
 - Source: `/home/tyler/syncthing` (hardcoded for my use case)
 - Compression: LZ4 (fast compression)
 - Excludes: Cache directories (via `--exclude-caches`), live DB trees (Postgres, MongoDB WiredTiger under `docker/`, Pi-hole, etc.) that are root-owned or unsafe to copy while running
+- **Database exports** (via `pg_dump` / etc. into `database-backup/` under each stack, then removed after the archive is created): Immich, Affine, Authentik, Miniflux, Sure (sure.am), Taiga, MongoDB, Vaultwarden, Uptime Kuma; Pi-hole config is tarballed separately
 
 ## Backup Schedule
 

--- a/borg/main.sh
+++ b/borg/main.sh
@@ -281,6 +281,22 @@ else
             fi
         fi
 
+        # Export Sure (sure.am) database (Postgres lives in a named Docker volume)
+        SURE_DIR="$HOME/git/docker/sure.am"
+        SURE_BACKUP_DIR="$SURE_DIR/database-backup"
+        if [ -d "$SURE_DIR" ] && command -v docker >/dev/null 2>&1; then
+            mkdir -p "$SURE_BACKUP_DIR"
+            if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^sure-db$'; then
+                if docker exec -t sure-db sh -c 'pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB"' > "$SURE_BACKUP_DIR/sure-database.sql" 2>/dev/null; then
+                    debug "Sure database dumped to database-backup/"
+                else
+                    warning "Failed to dump Sure database"
+                fi
+            else
+                debug "Sure postgres not running, skipping database dump"
+            fi
+        fi
+
         # Export Taiga Docker data for backup (DB, media, static)
         # Data is normally in named volumes - we export to a dir under git so it gets backed up
         TAIGA_DIR="$HOME/git/docker/taiga-docker"
@@ -562,7 +578,7 @@ else
 
         # Clean up exports (were captured in backup)
         for _dir in "${TAIGA_BACKUP_DIR:-}" "${IMMICH_BACKUP_DIR:-}" "${AFFINE_BACKUP_DIR:-}" "${AUTHENTIK_BACKUP_DIR:-}" "${MINIFLUX_BACKUP_DIR:-}" \
-            "${MONGODB_BACKUP_DIR:-}" "${VAULTWARDEN_BACKUP_DIR:-}" "${UPTIME_KUMA_BACKUP_DIR:-}" \
+            "${SURE_BACKUP_DIR:-}" "${MONGODB_BACKUP_DIR:-}" "${VAULTWARDEN_BACKUP_DIR:-}" "${UPTIME_KUMA_BACKUP_DIR:-}" \
             "$HOME/git/docker/pihole/cloud/pihole-backup" \
             "$HOME/git/docker/pihole/rainbow/pihole-backup"; do
             [ -d "$_dir" ] && rm -rf "$_dir"


### PR DESCRIPTION
Export sure-db via pg_dump into docker/sure.am/database-backup before the archive runs, matching Authentik and Miniflux.