### PR TITLE
tjw-290: Fix Spotify Last 25 cron and last_success monitoring

### DIFF
--- a/dailystatus/main.py
+++ b/dailystatus/main.py
@@ -418,8 +418,23 @@ def analyze_logs(email):
     return email, is_warnings, is_errors, only_food_log_error
 
 
+def _parse_spotify_last_success(value) -> datetime.datetime | None:
+    """Parse spotipy.last_success (YYYY-MM-DD HH:mm). Returns None if missing/invalid."""
+    if not value:
+        return None
+    try:
+        return datetime.datetime.strptime(str(value), "%Y-%m-%d %H:%M")
+    except (TypeError, ValueError):
+        return None
+
+
 def append_spotify_info(today, log_path_today, email):  # pylint: disable=redefined-outer-name
-    """append spotify issues and stats"""
+    """append spotify issues and stats
+
+    Returns:
+        tuple: (email_html, last_success_stale) where last_success_stale is True when
+        spotipy.last_success is missing or older than 24 hours.
+    """
     # Read from daily log and filter for SPOTIFY entries
     daily_log = (
         cab.get_file_as_array(
@@ -430,28 +445,49 @@ def append_spotify_info(today, log_path_today, email):  # pylint: disable=redefi
     spotify_log = [line for line in daily_log if "SPOTIFY" in line]
     spotify_stats = cab.get("spotipy") or {}
 
-    spotify_issues = "No Data"
+    issue_lines = []
     if spotify_log:
-        issues = [
+        issue_lines.extend(
             log
             for log in spotify_log
             if "WARNING" in log or "ERROR" in log or "CRITICAL" in log
-        ]
-        if issues:
-            spotify_issues = "<br>".join(issues)
-            email += f"<h3>Spotify Issues:</h3>{spotify_issues}<br><br>"
+        )
+
+    last_success_raw = spotify_stats.get("last_success")
+    last_success_dt = _parse_spotify_last_success(last_success_raw)
+    last_success_stale = False
+    if last_success_dt is None:
+        last_success_stale = True
+        issue_lines.append(
+            "SPOTIFY - last_success missing or invalid "
+            f"(value={last_success_raw!r})"
+        )
+    else:
+        age = datetime.datetime.now() - last_success_dt
+        if age > datetime.timedelta(hours=24):
+            last_success_stale = True
+            hours = age.total_seconds() / 3600
+            issue_lines.append(
+                f"SPOTIFY - last_success stale ({last_success_raw}, "
+                f"{hours:.0f}h ago; expected within 24h)"
+            )
+
+    if issue_lines:
+        email += f"<h3>Spotify Issues:</h3>{'<br>'.join(issue_lines)}<br><br>"
 
     total_tracks = spotify_stats.get("total_tracks", "No Data")
     average_year = spotify_stats.get("average_year", "No Data")
+    last_success_display = last_success_raw or "No Data"
 
     email += f"""
     <h3>Spotify Stats:</h3>
     <ul><b>Song Count:</b> {total_tracks}</ul>
     <ul><b>Average Year:</b> {average_year}</ul>
+    <ul><b>Last Success:</b> {last_success_display}</ul>
     <br>
     """
 
-    return email
+    return email, last_success_stale
 
 
 def append_weather_info(email):
@@ -543,12 +579,19 @@ if __name__ == "__main__":
     status_email = append_syncthing_conflict_check(status_email)
 
     # add spotify info
-    status_email = append_spotify_info(today, log_path_today, status_email)
+    status_email, spotify_last_success_stale = append_spotify_info(
+        today, log_path_today, status_email
+    )
 
     # analyze logs (24h via cab.log_query when Mongo enabled, else log files)
     status_email, has_warnings, has_errors, is_only_food_log_error = analyze_logs(
         status_email
     )
+
+    if spotify_last_success_stale:
+        has_errors = True
+        # Stale Spotify success is not a food-log-only failure
+        is_only_food_log_error = False
 
     # append weather info
     status_email = append_weather_info(status_email)

--- a/spotify_analytics/main.py
+++ b/spotify_analytics/main.py
@@ -24,7 +24,7 @@ from collections import Counter
 import re
 
 import spotipy
-from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOAuth, SpotifyOAuthError
+from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOAuth, SpotifyOauthError
 from cabinet import Cabinet
 from tyler_python_helpers import ChatGPT
 
@@ -1721,7 +1721,7 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
             return True
         error_str = str(exc).lower()
         return "invalid_grant" in error_str or (
-            isinstance(exc, SpotifyOAuthError) and "invalid_grant" in error_str
+            isinstance(exc, SpotifyOauthError) and "invalid_grant" in error_str
         )
 
     def _is_headless_environment(self) -> bool:
@@ -1802,7 +1802,7 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
 
         response = sys.stdin.readline().strip()
         if not response:
-            raise SpotifyOAuthError("No redirect URL provided")
+            raise SpotifyOauthError("No redirect URL provided")
         return response
 
     def _obtain_oauth_access_token(
@@ -1823,21 +1823,21 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         if auth_manager.open_browser:
             token = auth_manager.get_access_token(as_dict=False, check_cache=False)
             if not token:
-                raise SpotifyOAuthError("No access token returned from Spotify OAuth")
+                raise SpotifyOauthError("No access token returned from Spotify OAuth")
             return token
 
         redirect_url = self._prompt_for_redirect_url(auth_manager)
         try:
             code = auth_manager.parse_response_code(redirect_url)
-        except SpotifyOAuthError as e:
-            raise SpotifyOAuthError(
+        except SpotifyOauthError as e:
+            raise SpotifyOauthError(
                 "Invalid redirect URL. Paste the full URL from your browser address bar, "
                 f"including the 'code' parameter. {e}"
             ) from e
 
         token = auth_manager.get_access_token(code=code, check_cache=False)
         if not token:
-            raise SpotifyOAuthError("No access token returned from Spotify OAuth")
+            raise SpotifyOauthError("No access token returned from Spotify OAuth")
         return token
 
     def _get_oauth_config(self) -> Dict[str, Any]:
@@ -1963,7 +1963,7 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
             raise
 
         if not token:
-            raise SpotifyOAuthError("No access token returned from Spotify OAuth")
+            raise SpotifyOauthError("No access token returned from Spotify OAuth")
 
         oauth_client = spotipy.Spotify(auth_manager=auth_manager)
         try:
@@ -2128,7 +2128,7 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
                 self.cab.log(f"SPOTIFY - Reauthorization failed: {e}", level="error")
             self._discard_oauth_cache(cache_path)
             return False
-        except SpotifyOAuthError as e:
+        except SpotifyOauthError as e:
             self._discard_oauth_cache(cache_path)
             if self._is_invalid_grant_error(e):
                 self.cab.log(REAUTHORIZE_MESSAGE, level="error")
@@ -2151,6 +2151,17 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         # Match pattern: https://open.spotify.com/track/TRACK_ID
         match = re.search(r"track/([a-zA-Z0-9]+)", url)
         return match.group(1) if match else None
+
+    def _record_last_success(self) -> str:
+        """Record successful Last 25 Added update timestamp in cabinet.
+
+        Returns:
+            The timestamp string written to spotipy.last_success (YYYY-MM-DD HH:mm).
+        """
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M")
+        self.cab.put("spotipy", "last_success", timestamp)
+        self.cab.log(f"SPOTIFY - Recorded last_success={timestamp}")
+        return timestamp
 
     def update_last_25_added_playlist(self):
         """Update the 'Last 25 Added' playlist with the 25 most recently added tracks.
@@ -2253,6 +2264,7 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
             self.cab.log(
                 f"SPOTIFY - Successfully updated '{playlist_name}' with {len(track_ids)} tracks"
             )
+            self._record_last_success()
             return True
 
         except SpotifyReauthorizationRequired:


### PR DESCRIPTION
## Summary
- Fix `SpotifyOAuthError` → `SpotifyOauthError` import typo that crashed `spotify_analytics` on every cron run since tjw-258
- Record `spotipy.last_success` (`YYYY-MM-DD HH:mm`) after a successful Last 25 Added update
- Status email shows Last Success and treats missing/stale (>24h) as an error that bumps the subject to Check Errors

## Test plan
- [ ] `python3 spotify_analytics/main.py --update-last-25-only` completes and sets `cabinet get spotipy last_success`
- [ ] Confirm Last 25 Added playlist refreshed in Spotify
- [ ] Dry-run status email shows Last Success; with a stale/missing value it reports a Spotify Issue and Check Errors subject
- [ ] Next cron at 19:19 leaves a fresh `last_success` without import errors