### PR TITLE
TJW-295: Replicate Borg to rainbow despite warning exits

### DIFF
--- a/borg/main.sh
+++ b/borg/main.sh
@@ -459,6 +459,8 @@ else
         # docker/uptime-kuma/data/mariadb: live MariaDB; use mariadb-dump in database-backup/ instead
         # docker/vaultwarden/data db.sqlite* : use hot snapshot in database-backup/ instead
         # docker/rustdesk/data db_v2.sqlite3* : use hot snapshot in database-backup/ instead
+        # docker/rustdesk/data/.config : root:root 0600 (hbbs); causes Borg rc 1 / skipped
+        #   rainbow replicate. Service config is staged from /root/.config/rustdesk instead.
         # Capture both stdout and stderr - stdout has "E path" lines for skipped files
         # (Borg --list sends file listing to stdout, errors/warnings to stderr)
         # Staged paths: crontab temp dir may include etc-cloudflared, root-config-rustdesk.
@@ -488,6 +490,7 @@ else
             --exclude 'sh:**/docker/rustdesk/data/db_v2.sqlite3' \
             --exclude 'sh:**/docker/rustdesk/data/db_v2.sqlite3-wal' \
             --exclude 'sh:**/docker/rustdesk/data/db_v2.sqlite3-shm' \
+            --exclude 'sh:**/docker/rustdesk/data/.config' \
             --exclude 'sh:**/etc-pihole/cli_pw'     \
             --exclude 'sh:**/etc-pihole/logrotate'  \
             --exclude 're:etc-pihole'               \
@@ -758,8 +761,10 @@ else
     fi
 fi
 
+# Replicate on success or Borg warnings (rc 1 = archive OK, some paths skipped).
+# Only skip offsite rsync on hard failures (rc >= 2).
 debug "About to check if should replicate: global_exit=${global_exit}"
-if [ ${global_exit} -eq 0 ]; then
+if [ ${global_exit} -le 1 ]; then
     # Verify local repository before replicating; avoids copying corruption offsite
     # (Sundays may already have run borg check --verify-data; this is a quick structural check.)
     info "Running borg check before offsite replication"
@@ -771,7 +776,7 @@ if [ ${global_exit} -eq 0 ]; then
     fi
 fi
 
-if [ ${global_exit} -eq 0 ]; then
+if [ ${global_exit} -le 1 ]; then
     info "Replicating Borg repo to rainbow"
 
     # Convert ssh:// URI to rsync format if needed


### PR DESCRIPTION
## Summary
- Exclude `docker/rustdesk/data/.config` from `borg create` so root-owned `RustDesk.toml` no longer forces warning exit code 1 (service config still staged from `/root/.config/rustdesk`; hbbs DB via hot snapshot).
- Allow offsite rsync to rainbow when `global_exit -le 1` (Borg warning = archive OK), and only skip replicate on hard failures (`rc >= 2`).

## Context
Nightly cron skipped rainbow replication whenever Borg returned 1. Since 2026-07-06 that was triggered by permission denied on RustDesk.toml. Local archives continued; rainbow lagged until a one-shot `--replicate-only`.

## Test plan
- [ ] Confirm exclude is present: `rg "rustdesk/data/\.config" borg/main.sh`
- [ ] Confirm replicate gates use `-le 1` (not `-eq 0`)
- [ ] Optional: next cron night — rainbow archive advances with create; or dry-run path that would have been rc 1 still replicates
- [ ] Confirm hard failure path still skips rsync (rc >= 2)