### PR TITLE
TJW-245: Foodlog 2.0 with Grafana sync and submit gate

### DIFF
--- a/dailystatus/main.py
+++ b/dailystatus/main.py
@@ -146,30 +146,28 @@ def append_service_check_summary(email):
     return email
 
 
-def _food_log_paths():
-    """Resolve food.json / food_submitted.json from Cabinet path config."""
-    log_dir = cab.get("path", "cabinet", "log") or os.path.expanduser("~/syncthing/log")
-    return (
-        os.path.join(log_dir, "food.json"),
-        os.path.join(log_dir, "food_submitted.json"),
-    )
+def _foodlog_store():
+    """Lazy-import FoodlogStore from sibling foodlog package."""
+    foodlog_dir = os.path.join(os.path.dirname(__file__), "..", "foodlog")
+    if foodlog_dir not in sys.path:
+        sys.path.insert(0, os.path.abspath(foodlog_dir))
+    from store import get_store  # pylint: disable=import-outside-toplevel
+
+    return get_store()
 
 
 def is_foodlog_submitted(day: str, submitted_data: dict | None = None) -> bool:
     """True when ``foodlog submit`` has marked ``day`` (ISO date)."""
-    if submitted_data is None:
-        _, submitted_file = _food_log_paths()
-        if not os.path.exists(submitted_file):
-            return False
-        try:
-            with open(submitted_file, "r", encoding="utf-8") as f:
-                submitted_data = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            return False
-    value = submitted_data.get(day)
-    if isinstance(value, dict):
-        return bool(value.get("submitted"))
-    return bool(value)
+    if submitted_data is not None:
+        value = submitted_data.get(day)
+        if isinstance(value, dict):
+            return bool(value.get("submitted"))
+        return bool(value)
+    try:
+        return _foodlog_store().is_day_submitted(day)
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        cab.log(f"foodlog Mongo submitted check failed: {e}", level="error")
+        return False
 
 
 def append_food_log(email, dry_run=False):
@@ -179,7 +177,6 @@ def append_food_log(email, dry_run=False):
     Sends the foodlog reminder email only if ``foodlog submit`` has not been
     run for today (logging alone does not suppress the reminder).
     """
-    log_file, _submitted_file = _food_log_paths()
     today_str = datetime.date.today().isoformat()
 
     if not is_foodlog_submitted(today_str):
@@ -190,17 +187,22 @@ def append_food_log(email, dry_run=False):
                 "Log your food, then run `foodlog submit` when done.",
             )
 
-    if not os.path.exists(log_file):
-        cab.log("Food log file does not exist.", level="error")
-        return email
-
     try:
-        with open(log_file, "r", encoding="utf-8") as f:
-            log_data = json.load(f)
-
-        if today_str in log_data and log_data[today_str]:
-            total_calories = sum(entry["calories"] for entry in log_data[today_str])
-            submitted_note = " (submitted)" if is_foodlog_submitted(today_str) else ""
+        store = _foodlog_store()
+        # One-time migrate if Mongo empty but flat files exist
+        log_dir = cab.get("path", "cabinet", "log") or os.path.expanduser(
+            "~/syncthing/log"
+        )
+        store.migrate_from_json_files(
+            os.path.join(log_dir, "food.json"),
+            os.path.join(log_dir, "food_lookup.json"),
+            os.path.join(log_dir, "food_submitted.json"),
+            only_if_empty=True,
+        )
+        entries = store.get_entries(today_str)
+        if entries:
+            total_calories = sum(entry.get("calories", 0) for entry in entries)
+            submitted_note = " (submitted)" if store.is_day_submitted(today_str) else ""
             return email + textwrap.dedent(
                 f"""
             <h3>Calories Eaten Today:</h3>
@@ -210,9 +212,8 @@ def append_food_log(email, dry_run=False):
             """
             )
         return email
-
-    except (json.JSONDecodeError, OSError):
-        cab.log("Error reading food log file.", level="error")
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        cab.log(f"Error reading foodlog MongoDB: {e}", level="error")
         return email
 
 
@@ -423,21 +424,16 @@ def _apply_foodlog_goals_response(
 
 def append_nutrition_summary(email):
     """Append a bulleted summary of nutritional quality from the past 7 days via ChatGPT."""
-    log_file = _food_log_paths()[0]
-
-    if not os.path.exists(log_file):
-        cab.log("Food log file does not exist for nutrition summary.", level="error")
-        return email
-
     try:
-        with open(log_file, "r", encoding="utf-8") as f:
-            log_data = json.load(f)
-    except (json.JSONDecodeError, OSError) as e:
-        cab.log(f"Error reading food log for nutrition summary: {e}", level="error")
+        store = _foodlog_store()
+        today_day = datetime.date.today()
+        start = (today_day - datetime.timedelta(days=6)).isoformat()
+        log_data = store.list_days_between(start, today_day.isoformat())
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        cab.log(f"Error reading foodlog MongoDB for nutrition summary: {e}", level="error")
         return email
 
     # Build food log for past 7 days
-    today_day = datetime.date.today()
     week_entries = []
     for i in range(7):
         date = today_day - datetime.timedelta(days=i)

--- a/dailystatus/main.py
+++ b/dailystatus/main.py
@@ -146,10 +146,49 @@ def append_service_check_summary(email):
     return email
 
 
+def _food_log_paths():
+    """Resolve food.json / food_submitted.json from Cabinet path config."""
+    log_dir = cab.get("path", "cabinet", "log") or os.path.expanduser("~/syncthing/log")
+    return (
+        os.path.join(log_dir, "food.json"),
+        os.path.join(log_dir, "food_submitted.json"),
+    )
+
+
+def is_foodlog_submitted(day: str, submitted_data: dict | None = None) -> bool:
+    """True when ``foodlog submit`` has marked ``day`` (ISO date)."""
+    if submitted_data is None:
+        _, submitted_file = _food_log_paths()
+        if not os.path.exists(submitted_file):
+            return False
+        try:
+            with open(submitted_file, "r", encoding="utf-8") as f:
+                submitted_data = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return False
+    value = submitted_data.get(day)
+    if isinstance(value, dict):
+        return bool(value.get("submitted"))
+    return bool(value)
+
+
 def append_food_log(email, dry_run=False):
-    """check if food has been logged today, print total calories or an error if none found."""
-    log_file = os.path.expanduser("~/syncthing/log/food.json")
+    """
+    Append today's calorie total when food was logged.
+
+    Sends the foodlog reminder email only if ``foodlog submit`` has not been
+    run for today (logging alone does not suppress the reminder).
+    """
+    log_file, _submitted_file = _food_log_paths()
     today_str = datetime.date.today().isoformat()
+
+    if not is_foodlog_submitted(today_str):
+        if not dry_run:
+            mail.send(
+                "🍊 Log food for today!",
+                "Food log not submitted for today. "
+                "Log your food, then run `foodlog submit` when done.",
+            )
 
     if not os.path.exists(log_file):
         cab.log("Food log file does not exist.", level="error")
@@ -159,21 +198,18 @@ def append_food_log(email, dry_run=False):
         with open(log_file, "r", encoding="utf-8") as f:
             log_data = json.load(f)
 
-        if today_str not in log_data or not log_data[today_str]:
-            if not dry_run:
-                mail.send("🍊 Log food for today!",
-                "No food logged for today. Please log your food for today.")
-            return email
-        else:
+        if today_str in log_data and log_data[today_str]:
             total_calories = sum(entry["calories"] for entry in log_data[today_str])
+            submitted_note = " (submitted)" if is_foodlog_submitted(today_str) else ""
             return email + textwrap.dedent(
                 f"""
             <h3>Calories Eaten Today:</h3>
             <pre style="font-family: monospace; white-space: pre-wrap;"
-            >{total_calories} calories</pre>
+            >{total_calories} calories{submitted_note}</pre>
             <br>
             """
             )
+        return email
 
     except (json.JSONDecodeError, OSError):
         cab.log("Error reading food log file.", level="error")
@@ -387,7 +423,7 @@ def _apply_foodlog_goals_response(
 
 def append_nutrition_summary(email):
     """Append a bulleted summary of nutritional quality from the past 7 days via ChatGPT."""
-    log_file = os.path.expanduser("~/syncthing/log/food.json")
+    log_file = _food_log_paths()[0]
 
     if not os.path.exists(log_file):
         cab.log("Food log file does not exist for nutrition summary.", level="error")

--- a/dailystatus/test_foodlog_submit.py
+++ b/dailystatus/test_foodlog_submit.py
@@ -1,12 +1,24 @@
 """Tests for foodlog submit gating in dailystatus (TJW-245)."""
 
-import json
-import tempfile
 import unittest
-from pathlib import Path
 from unittest import mock
 
 from main import append_food_log, is_foodlog_submitted
+
+
+class _FakeStore:
+    def __init__(self, entries=None, submitted=False):
+        self._entries = entries or []
+        self._submitted = submitted
+
+    def is_day_submitted(self, day):  # pylint: disable=unused-argument
+        return self._submitted
+
+    def get_entries(self, day):  # pylint: disable=unused-argument
+        return self._entries
+
+    def migrate_from_json_files(self, *args, **kwargs):  # pylint: disable=unused-argument
+        return 0
 
 
 class FoodlogSubmitTests(unittest.TestCase):
@@ -21,73 +33,44 @@ class FoodlogSubmitTests(unittest.TestCase):
         )
 
     def test_append_food_log_reminds_when_not_submitted(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            log_file = Path(tmp) / "food.json"
-            submitted_file = Path(tmp) / "food_submitted.json"
-            today = "2026-07-20"
-            log_file.write_text(
-                json.dumps({today: [{"food": "apple", "calories": 50}]}),
-                encoding="utf-8",
-            )
-            submitted_file.write_text("{}", encoding="utf-8")
+        store = _FakeStore(
+            entries=[{"food": "apple", "calories": 50}],
+            submitted=False,
+        )
+        with mock.patch("main.datetime") as dt:
+            dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
+            with mock.patch("main._foodlog_store", return_value=store):
+                with mock.patch("main.mail") as mail:
+                    email = append_food_log("", dry_run=False)
 
-            with mock.patch("main.datetime") as dt:
-                dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
-                with mock.patch(
-                    "main._food_log_paths",
-                    return_value=(str(log_file), str(submitted_file)),
-                ):
-                    with mock.patch("main.mail") as mail:
-                        email = append_food_log("", dry_run=False)
-
-            mail.send.assert_called_once()
-            self.assertIn("50 calories", email)
-            self.assertNotIn("submitted", email)
+        mail.send.assert_called_once()
+        self.assertIn("50 calories", email)
+        self.assertNotIn("submitted", email)
 
     def test_append_food_log_skips_reminder_when_submitted(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            log_file = Path(tmp) / "food.json"
-            submitted_file = Path(tmp) / "food_submitted.json"
-            today = "2026-07-20"
-            log_file.write_text(
-                json.dumps({today: [{"food": "apple", "calories": 50}]}),
-                encoding="utf-8",
-            )
-            submitted_file.write_text(
-                json.dumps({today: {"submitted": True}}),
-                encoding="utf-8",
-            )
+        store = _FakeStore(
+            entries=[{"food": "apple", "calories": 50}],
+            submitted=True,
+        )
+        with mock.patch("main.datetime") as dt:
+            dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
+            with mock.patch("main._foodlog_store", return_value=store):
+                with mock.patch("main.mail") as mail:
+                    email = append_food_log("", dry_run=False)
 
-            with mock.patch("main.datetime") as dt:
-                dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
-                with mock.patch(
-                    "main._food_log_paths",
-                    return_value=(str(log_file), str(submitted_file)),
-                ):
-                    with mock.patch("main.mail") as mail:
-                        email = append_food_log("", dry_run=False)
-
-            mail.send.assert_not_called()
-            self.assertIn("50 calories (submitted)", email)
+        mail.send.assert_not_called()
+        self.assertIn("50 calories (submitted)", email)
 
     def test_append_food_log_reminds_even_with_no_entries(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            log_file = Path(tmp) / "food.json"
-            submitted_file = Path(tmp) / "food_submitted.json"
-            log_file.write_text("{}", encoding="utf-8")
-            submitted_file.write_text("{}", encoding="utf-8")
+        store = _FakeStore(entries=[], submitted=False)
+        with mock.patch("main.datetime") as dt:
+            dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
+            with mock.patch("main._foodlog_store", return_value=store):
+                with mock.patch("main.mail") as mail:
+                    email = append_food_log("base", dry_run=False)
 
-            with mock.patch("main.datetime") as dt:
-                dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
-                with mock.patch(
-                    "main._food_log_paths",
-                    return_value=(str(log_file), str(submitted_file)),
-                ):
-                    with mock.patch("main.mail") as mail:
-                        email = append_food_log("base", dry_run=False)
-
-            mail.send.assert_called_once()
-            self.assertEqual(email, "base")
+        mail.send.assert_called_once()
+        self.assertEqual(email, "base")
 
 
 if __name__ == "__main__":

--- a/dailystatus/test_foodlog_submit.py
+++ b/dailystatus/test_foodlog_submit.py
@@ -1,0 +1,94 @@
+"""Tests for foodlog submit gating in dailystatus (TJW-245)."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from main import append_food_log, is_foodlog_submitted
+
+
+class FoodlogSubmitTests(unittest.TestCase):
+    def test_is_foodlog_submitted_shapes(self):
+        self.assertFalse(is_foodlog_submitted("2026-07-20", {}))
+        self.assertTrue(is_foodlog_submitted("2026-07-20", {"2026-07-20": True}))
+        self.assertTrue(
+            is_foodlog_submitted("2026-07-20", {"2026-07-20": {"submitted": True}})
+        )
+        self.assertFalse(
+            is_foodlog_submitted("2026-07-20", {"2026-07-20": {"submitted": False}})
+        )
+
+    def test_append_food_log_reminds_when_not_submitted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_file = Path(tmp) / "food.json"
+            submitted_file = Path(tmp) / "food_submitted.json"
+            today = "2026-07-20"
+            log_file.write_text(
+                json.dumps({today: [{"food": "apple", "calories": 50}]}),
+                encoding="utf-8",
+            )
+            submitted_file.write_text("{}", encoding="utf-8")
+
+            with mock.patch("main.datetime") as dt:
+                dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
+                with mock.patch(
+                    "main._food_log_paths",
+                    return_value=(str(log_file), str(submitted_file)),
+                ):
+                    with mock.patch("main.mail") as mail:
+                        email = append_food_log("", dry_run=False)
+
+            mail.send.assert_called_once()
+            self.assertIn("50 calories", email)
+            self.assertNotIn("submitted", email)
+
+    def test_append_food_log_skips_reminder_when_submitted(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_file = Path(tmp) / "food.json"
+            submitted_file = Path(tmp) / "food_submitted.json"
+            today = "2026-07-20"
+            log_file.write_text(
+                json.dumps({today: [{"food": "apple", "calories": 50}]}),
+                encoding="utf-8",
+            )
+            submitted_file.write_text(
+                json.dumps({today: {"submitted": True}}),
+                encoding="utf-8",
+            )
+
+            with mock.patch("main.datetime") as dt:
+                dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
+                with mock.patch(
+                    "main._food_log_paths",
+                    return_value=(str(log_file), str(submitted_file)),
+                ):
+                    with mock.patch("main.mail") as mail:
+                        email = append_food_log("", dry_run=False)
+
+            mail.send.assert_not_called()
+            self.assertIn("50 calories (submitted)", email)
+
+    def test_append_food_log_reminds_even_with_no_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log_file = Path(tmp) / "food.json"
+            submitted_file = Path(tmp) / "food_submitted.json"
+            log_file.write_text("{}", encoding="utf-8")
+            submitted_file.write_text("{}", encoding="utf-8")
+
+            with mock.patch("main.datetime") as dt:
+                dt.date.today.return_value = __import__("datetime").date(2026, 7, 20)
+                with mock.patch(
+                    "main._food_log_paths",
+                    return_value=(str(log_file), str(submitted_file)),
+                ):
+                    with mock.patch("main.mail") as mail:
+                        email = append_food_log("base", dry_run=False)
+
+            mail.send.assert_called_once()
+            self.assertEqual(email, "base")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/foodlog/README.md
+++ b/foodlog/README.md
@@ -1,16 +1,16 @@
 # Food Log
 
-A simple command-line tool for logging food entries and tracking calories. The tool automatically classifies foods as healthy or junk and provides a visual summary of your eating habits. Daily totals sync to the existing Grafana/Loki stack so you can spot patterns over time.
+A simple command-line tool for logging food entries and tracking calories. Data lives in a dedicated **MongoDB database `foodlog`** on the same server as Cabinet (peer to the `cabinet` DB). Grafana charts the `days` collection directly; optional Loki snapshots remain for log-style views.
 
 ## Features
 
-- Log food entries with calorie counts
+- Log food entries with calorie counts (MongoDB source of truth)
 - Automatic food classification (healthy vs junk)
 - Visual summary of daily calorie intake with healthy/junk breakdown
 - Food lookup database to remember calorie counts
 - AI-powered calorie suggestions for unknown foods
 - `foodlog submit` to mark the day done (skips the dailystatus reminder email)
-- Grafana sync via Cabinet `logging.loki_url` (updates as you log)
+- Grafana: MongoDB datasource + Foodlog dashboard; optional Loki sync
 
 ## Usage
 
@@ -24,19 +24,10 @@ Example:
 foodlog "chicken salad" 540
 ```
 
-Each log (and undo) updates `food.json` and pushes that day's total to Loki so Grafana charts stay current.
-
 ### Multiple Entries
-You can log multiple food entries in a single command using `//` as a separator. Each side of `//` is treated as a separate command:
-
 ```bash
-# Log two foods with their own calorie counts
 foodlog "apple" 50 // "banana" 60
-
-# Mix and match with lookup
 foodlog "apple" // "banana" 60 // "cookies"
-
-# Use with --yesterday (only applies to the command it's associated with)
 foodlog "apple" 50 // "banana" 60 --yesterday
 ```
 
@@ -52,67 +43,69 @@ foodlog submit
 foodlog --submit
 ```
 
-Daily status sends the “log food” reminder only if today has **not** been submitted. Logging food alone does not clear the reminder.
+Daily status sends the “log food” reminder only if today has **not** been submitted.
 
-### Sync history to Grafana
+### Migrate legacy flat files → Mongo
+```bash
+foodlog --migrate
+```
+
+On first use, if the `foodlog` DB is empty, flat files under Cabinet’s log path are imported automatically.
+
+### Sync snapshots to Loki (optional)
 ```bash
 foodlog --sync-grafana
 ```
-
-Backfills every day in `food.json` to Loki (uses Cabinet `logging.loki_url`).
 
 ### View Summary
 ```bash
 foodlog --summary
 ```
-The summary view shows:
-- Food entries for the past 7 days
-- Total calories and percentage of healthy vs junk food
-- Visual bar graph where:
-  - Bar length represents total calories (shorter = fewer calories)
-  - Green portion represents healthy calories
-  - Red portion represents junk calories
 
 ### Edit Food Log
 ```bash
 foodlog --edit
 ```
+Exports days to a temp JSON, opens your Cabinet editor, then re-imports into Mongo.
 
 ### Log to Yesterday
 ```bash
-# in case you forgot yesterday!
 foodlog "chicken salad" 500 --yesterday
 ```
 
 ## Data Storage
 
-Flat files under Cabinet `path -> cabinet -> log` (fallback `~/.cabinet/log`):
+**MongoDB** (same URI as Cabinet `mongodb_connection_string`, database name `foodlog`):
 
-- `food.json` — entries keyed by ISO date (unchanged structure)
-- `food_lookup.json` — remembered calorie counts / classifications
-- `food_submitted.json` — days marked with `foodlog submit`
+| Collection | Contents |
+|------------|----------|
+| `days` | One document per ISO date: `entries[]`, `total_calories`, `submitted`, `date_time` |
+| `lookup` | Food name → calories / healthy\|junk type |
+
+Legacy flat files (migration only): `food.json`, `food_lookup.json`, `food_submitted.json` under Cabinet `path -> cabinet -> log`.
 
 ## Grafana
 
-Uses the existing Grafana app (Loki datasource). Foodlog pushes `job=foodlog` daily snapshots when `logging.loki_url` is set in Cabinet config. Example LogQL:
+The Loki stack provisions:
 
-```logql
-{job="foodlog", type="daily"} | json | unwrap total_calories
-```
+1. **Foodlog MongoDB** datasource (`haohanyang-mongodb-datasource`) → database `foodlog`
+2. **Foodlog** dashboard (Mongo time series of `total_calories`)
+
+OSS Grafana cannot use Grafana’s Enterprise Mongo plugin; the community plugin is installed via compose.
 
 ## Configuration
 
-The tool uses:
-- [Cabinet](https://www.github.com/tylerjwoodfin/cabinet).
-  - You can set:
-    - `foodlog -> calorie_target`: Your daily calorie target (default: 1750)
-    - `keys -> openai`: Your OpenAI API key for AI-powered features
-    - `logging -> loki_url`: Loki base URL for Grafana sync (same as Cabinet logs)
-- [tyler-python-helpers](https://github.com/tylerjwoodfin/python-helpers)
-  - `pipx install tyler-python-helpers`
+- [Cabinet](https://www.github.com/tylerjwoodfin/cabinet)
+  - `foodlog -> calorie_target` (default 1750)
+  - `mongodb_connection_string` / `mongodb_enabled` (shared Mongo server)
+  - `logging -> loki_url` (optional Loki sync)
+  - `keys -> openai` for AI features
+- Override URI with env `FOODLOG_MONGO_URI` if needed
+- [tyler-python-helpers](https://github.com/tylerjwoodfin/python-helpers) — `pipx install tyler-python-helpers`
+- `pymongo` (same as Cabinet)
 
 ## Notes
 
-- The tool automatically classifies foods as healthy or junk based on common nutritional knowledge
-- For new foods, you can use the 'ai' option to get calorie suggestions from ChatGPT
-- The summary view's bar graph scales based on your highest calorie day, making it easy to compare daily intake
+- Foods are classified as healthy or junk for the summary view
+- Use `ai` at the calorie prompt for ChatGPT suggestions
+- Summary bar graph scales to your highest calorie day in the window

--- a/foodlog/README.md
+++ b/foodlog/README.md
@@ -1,6 +1,6 @@
 # Food Log
 
-A simple command-line tool for logging food entries and tracking calories. The tool automatically classifies foods as healthy or junk and provides a visual summary of your eating habits.
+A simple command-line tool for logging food entries and tracking calories. The tool automatically classifies foods as healthy or junk and provides a visual summary of your eating habits. Daily totals sync to the existing Grafana/Loki stack so you can spot patterns over time.
 
 ## Features
 
@@ -9,6 +9,8 @@ A simple command-line tool for logging food entries and tracking calories. The t
 - Visual summary of daily calorie intake with healthy/junk breakdown
 - Food lookup database to remember calorie counts
 - AI-powered calorie suggestions for unknown foods
+- `foodlog submit` to mark the day done (skips the dailystatus reminder email)
+- Grafana sync via Cabinet `logging.loki_url` (updates as you log)
 
 ## Usage
 
@@ -21,6 +23,8 @@ Example:
 ```bash
 foodlog "chicken salad" 540
 ```
+
+Each log (and undo) updates `food.json` and pushes that day's total to Loki so Grafana charts stay current.
 
 ### Multiple Entries
 You can log multiple food entries in a single command using `//` as a separator. Each side of `//` is treated as a separate command:
@@ -41,6 +45,22 @@ foodlog "apple" 50 // "banana" 60 --yesterday
 foodlog
 ```
 
+### Submit the day (disable dailystatus reminder)
+```bash
+foodlog submit
+# or
+foodlog --submit
+```
+
+Daily status sends the “log food” reminder only if today has **not** been submitted. Logging food alone does not clear the reminder.
+
+### Sync history to Grafana
+```bash
+foodlog --sync-grafana
+```
+
+Backfills every day in `food.json` to Loki (uses Cabinet `logging.loki_url`).
+
 ### View Summary
 ```bash
 foodlog --summary
@@ -58,7 +78,7 @@ The summary view shows:
 foodlog --edit
 ```
 
-### Log to Yesterda
+### Log to Yesterday
 ```bash
 # in case you forgot yesterday!
 foodlog "chicken salad" 500 --yesterday
@@ -66,16 +86,28 @@ foodlog "chicken salad" 500 --yesterday
 
 ## Data Storage
 
-- Food entries are stored in `~/.cabinet/log/food.json`
-- Food lookup database is stored in `~/.cabinet/log/food_lookup.json`
+Flat files under Cabinet `path -> cabinet -> log` (fallback `~/.cabinet/log`):
+
+- `food.json` — entries keyed by ISO date (unchanged structure)
+- `food_lookup.json` — remembered calorie counts / classifications
+- `food_submitted.json` — days marked with `foodlog submit`
+
+## Grafana
+
+Uses the existing Grafana app (Loki datasource). Foodlog pushes `job=foodlog` daily snapshots when `logging.loki_url` is set in Cabinet config. Example LogQL:
+
+```logql
+{job="foodlog", type="daily"} | json | unwrap total_calories
+```
 
 ## Configuration
 
 The tool uses:
-- [Cabinet](https://www.github.com/tylerjwoodfin/cabinet). 
+- [Cabinet](https://www.github.com/tylerjwoodfin/cabinet).
   - You can set:
     - `foodlog -> calorie_target`: Your daily calorie target (default: 1750)
     - `keys -> openai`: Your OpenAI API key for AI-powered features
+    - `logging -> loki_url`: Loki base URL for Grafana sync (same as Cabinet logs)
 - [tyler-python-helpers](https://github.com/tylerjwoodfin/python-helpers)
   - `pipx install tyler-python-helpers`
 

--- a/foodlog/main.py
+++ b/foodlog/main.py
@@ -158,9 +158,9 @@ def build_loki_push_body(event: dict, timestamp: datetime.datetime | None = None
 
 def push_event_to_loki(event: dict, loki_url: str | None = None) -> bool:
     """
-    POST a foodlog event to Loki for Grafana.
+    POST a foodlog event to Loki (optional; Grafana charts Mongo directly).
 
-    Returns True on success. No-op (False) when Loki URL is unset.
+    Returns True on success. No-op (False) when Loki URL is unset or unreachable.
     """
     base = (loki_url or _loki_base_url() or "").rstrip("/")
     if not base:
@@ -175,8 +175,11 @@ def push_event_to_loki(event: dict, loki_url: str | None = None) -> bool:
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             return 200 <= getattr(resp, "status", 200) < 300
-    except (urllib.error.URLError, TimeoutError, OSError) as exc:
-        cabinet.log(f"foodlog Grafana/Loki push failed: {exc}", level="warning")
+    except (urllib.error.URLError, TimeoutError, OSError, socket.gaierror) as exc:
+        cabinet.log(
+            f"foodlog optional Loki push failed (Mongo is source of truth): {exc}",
+            level="debug",
+        )
         return False
 
 
@@ -220,7 +223,6 @@ def log_food(food_name: str, calories: int, is_yesterday: bool = False) -> None:
     print_formatted_text(
         HTML(f"<green>Logged:</green> {food_name} <yellow>({calories} cal)</yellow>")
     )
-    sync_day_to_grafana(today)
 
     if globals().get("_is_last_main_call", False):
         display_daily_calories()
@@ -519,9 +521,8 @@ def show_summary() -> None:
 
 
 def submit_day(day: str | None = None) -> None:
-    """Mark the day submitted and sync the snapshot to Grafana/Loki."""
+    """Mark the day submitted (Mongo). Optional Loki sync is via --sync-grafana."""
     day = mark_day_submitted(day)
-    sync_day_to_grafana(day)
     print_formatted_text(
         HTML(
             f"<green>Submitted</green> food log for <yellow>{day}</yellow>. "
@@ -649,7 +650,6 @@ def undo_latest_entry() -> None:
 
     food_name = removed_entry["food"]
     calories = removed_entry["calories"]
-    sync_day_to_grafana(today)
     print_formatted_text(
         HTML(f"<green>Removed:</green> {food_name} <yellow>({calories} cal)</yellow>")
     )

--- a/foodlog/main.py
+++ b/foodlog/main.py
@@ -7,25 +7,56 @@ import sys
 import os
 import datetime
 import socket
+import tempfile
 import urllib.error
 import urllib.request
 from tyler_python_helpers import ChatGPT
 from prompt_toolkit import print_formatted_text, HTML
 from cabinet import Cabinet
 
+from store import (
+    day_total_calories,
+    get_store,
+    normalize_calories,
+)
+
 cabinet = Cabinet()
 chatgpt = ChatGPT()
 
-# define file paths
+# Legacy flat-file paths (used for one-time Mongo migration / optional export)
 LOG_DIR = cabinet.get("path", "cabinet", "log") or os.path.expanduser("~/.cabinet/log")
 FOOD_LOG_FILE = os.path.join(LOG_DIR, "food.json")
 FOOD_LOOKUP_FILE = os.path.join(LOG_DIR, "food_lookup.json")
 FOOD_SUBMITTED_FILE = os.path.join(LOG_DIR, "food_submitted.json")
 
+_MIGRATED = False
+
 
 def ensure_log_directory() -> None:
-    """create log directory if it doesn't exist."""
+    """create log directory if it doesn't exist (legacy export / edit temp)."""
     os.makedirs(LOG_DIR, exist_ok=True)
+
+
+def _ensure_migrated() -> None:
+    """Import flat files into Mongo once if the foodlog DB is empty."""
+    global _MIGRATED  # pylint: disable=global-statement
+    if _MIGRATED:
+        return
+    store = get_store()
+    imported = store.migrate_from_json_files(
+        FOOD_LOG_FILE,
+        FOOD_LOOKUP_FILE,
+        FOOD_SUBMITTED_FILE,
+        only_if_empty=True,
+    )
+    if imported:
+        print_formatted_text(
+            HTML(
+                f"<green>Migrated</green> <yellow>{imported}</yellow> day(s) "
+                "from flat files into MongoDB database <yellow>foodlog</yellow>."
+            )
+        )
+    _MIGRATED = True
 
 
 def load_json(file_path: str) -> dict:
@@ -42,31 +73,15 @@ def save_json(file_path: str, data: dict) -> None:
         json.dump(data, f, indent=4)
 
 
-def _normalize_calories(calories) -> int:
-    """Coerce calorie values (int, numeric str, or nested dict) to int."""
-    if isinstance(calories, dict):
-        return int(calories.get("calories", 0) or 0)
-    if isinstance(calories, str) and calories.isnumeric():
-        return int(calories)
-    return int(calories)
-
-
-def day_total_calories(entries: list) -> int:
-    """Sum calorie counts for a list of food log entries."""
-    total = 0
-    for entry in entries:
-        total += _normalize_calories(entry.get("calories", 0))
-    return total
-
-
 def is_day_submitted(day: str, submitted_data: dict | None = None) -> bool:
     """Return True if ``foodlog submit`` has been run for ``day`` (ISO date)."""
-    if submitted_data is None:
-        submitted_data = load_json(FOOD_SUBMITTED_FILE)
-    value = submitted_data.get(day)
-    if isinstance(value, dict):
-        return bool(value.get("submitted"))
-    return bool(value)
+    if submitted_data is not None:
+        value = submitted_data.get(day)
+        if isinstance(value, dict):
+            return bool(value.get("submitted"))
+        return bool(value)
+    _ensure_migrated()
+    return get_store().is_day_submitted(day)
 
 
 def mark_day_submitted(day: str | None = None) -> str:
@@ -75,15 +90,8 @@ def mark_day_submitted(day: str | None = None) -> str:
 
     Returns the ISO date that was marked.
     """
-    ensure_log_directory()
-    day = day or datetime.date.today().isoformat()
-    submitted_data = load_json(FOOD_SUBMITTED_FILE)
-    submitted_data[day] = {
-        "submitted": True,
-        "submitted_at": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
-    }
-    save_json(FOOD_SUBMITTED_FILE, submitted_data)
-    return day
+    _ensure_migrated()
+    return get_store().mark_submitted(day)
 
 
 def _loki_base_url() -> str | None:
@@ -110,7 +118,7 @@ def build_daily_grafana_event(
         "foods": [
             {
                 "food": e.get("food", "unknown"),
-                "calories": _normalize_calories(e.get("calories", 0)),
+                "calories": normalize_calories(e.get("calories", 0)),
             }
             for e in entries
         ],
@@ -173,23 +181,25 @@ def push_event_to_loki(event: dict, loki_url: str | None = None) -> bool:
 
 
 def sync_day_to_grafana(day: str | None = None, log_data: dict | None = None) -> bool:
-    """Push one day's totals from flat-file food.json to Loki (existing Grafana)."""
+    """Push one day's totals from Mongo (or provided map) to Loki."""
+    _ensure_migrated()
     day = day or datetime.date.today().isoformat()
+    store = get_store()
     if log_data is None:
-        log_data = load_json(FOOD_LOG_FILE)
-    entries = log_data.get(day, [])
-    event = build_daily_grafana_event(
-        day,
-        entries,
-        submitted=is_day_submitted(day),
-    )
+        entries = store.get_entries(day)
+        submitted = store.is_day_submitted(day)
+    else:
+        entries = log_data.get(day, [])
+        submitted = is_day_submitted(day)
+    event = build_daily_grafana_event(day, entries, submitted=submitted)
     return push_event_to_loki(event)
 
 
 def sync_all_to_grafana(log_data: dict | None = None) -> int:
-    """Backfill all days in food.json to Loki. Returns number of successful pushes."""
+    """Backfill all days to Loki. Returns number of successful pushes."""
+    _ensure_migrated()
     if log_data is None:
-        log_data = load_json(FOOD_LOG_FILE)
+        log_data = get_store().all_days_map()
     ok = 0
     for day in sorted(log_data.keys()):
         if sync_day_to_grafana(day, log_data=log_data):
@@ -199,39 +209,29 @@ def sync_all_to_grafana(log_data: dict | None = None) -> int:
 
 def log_food(food_name: str, calories: int, is_yesterday: bool = False) -> None:
     """log food entry for today's date."""
-    ensure_log_directory()
-    log_data = load_json(FOOD_LOG_FILE)
+    _ensure_migrated()
     today = datetime.date.today().isoformat()
-
     if is_yesterday:
         today = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
 
-    if today not in log_data:
-        log_data[today] = []
-
-    calories = _normalize_calories(calories)
-
-    # Store food name in lowercase for consistency
+    calories = normalize_calories(calories)
     food_name_lower = food_name.lower()
-    log_data[today].append({"food": food_name_lower, "calories": calories})
-    save_json(FOOD_LOG_FILE, log_data)
+    get_store().append_entry(today, food_name_lower, calories)
     print_formatted_text(
         HTML(f"<green>Logged:</green> {food_name} <yellow>({calories} cal)</yellow>")
     )
-    sync_day_to_grafana(today, log_data=log_data)
+    sync_day_to_grafana(today)
 
     if globals().get("_is_last_main_call", False):
         display_daily_calories()
 
 
 def update_food_lookup(food_name: str, calories: int) -> None:
-    """update food lookup file with food and calorie information."""
-    lookup_data = load_json(FOOD_LOOKUP_FILE)
-
-    if isinstance(calories, str) and calories.isnumeric():
-        calories = int(calories)
-
-    # Store food name in lowercase for case-insensitive lookups
+    """update food lookup with food and calorie information."""
+    _ensure_migrated()
+    store = get_store()
+    lookup_data = store.get_lookup()
+    calories = normalize_calories(calories)
     food_name_lower = food_name.lower()
 
     if food_name_lower in lookup_data:
@@ -249,23 +249,19 @@ def update_food_lookup(food_name: str, calories: int) -> None:
                 )
             )
     else:
-        lookup_data[food_name_lower] = {"calories": calories, "type": "unknown"}
-
-    save_json(FOOD_LOOKUP_FILE, lookup_data)
+        store.upsert_lookup(food_name_lower, calories, food_type="unknown")
 
 
 def force_update_food_lookup(food_name: str, calories: int) -> None:
-    """force update food lookup file with new calorie information."""
-    lookup_data = load_json(FOOD_LOOKUP_FILE)
-
-    if isinstance(calories, str) and calories.isnumeric():
-        calories = int(calories)
-
-    # Store food name in lowercase for case-insensitive lookups
+    """force update food lookup with new calorie information."""
+    _ensure_migrated()
+    store = get_store()
+    lookup_data = store.get_lookup()
+    calories = normalize_calories(calories)
     food_name_lower = food_name.lower()
 
     old_calories = lookup_data.get(food_name_lower, {}).get("calories", "unknown")
-    lookup_data[food_name_lower] = {"calories": calories, "type": "unknown"}
+    store.upsert_lookup(food_name_lower, calories, food_type="unknown")
 
     print_formatted_text(
         HTML(
@@ -274,34 +270,29 @@ def force_update_food_lookup(food_name: str, calories: int) -> None:
         )
     )
 
-    save_json(FOOD_LOOKUP_FILE, lookup_data)
-
 
 def display_daily_calories(target_date: datetime.date = None) -> None:
     """display total calorie count and entries for a specific date (defaults to today)."""
-    log_data = load_json(FOOD_LOG_FILE)
+    _ensure_migrated()
+    store = get_store()
     if target_date is None:
         target_date = datetime.date.today()
 
     target_date_str = target_date.isoformat()
+    entries = store.get_entries(target_date_str)
 
-    if target_date_str in log_data:
-        # Format the date as "Food for Day, YYYY-MM-DD"
+    if entries:
         formatted_date = f"\n{target_date.strftime('%a')}, {target_date_str}"
         print_formatted_text(
             HTML(f"<underline><bold>{formatted_date}</bold></underline>")
         )
         total_calories = 0
 
-        # Find the maximum length of calories for alignment
-        for entry in log_data[target_date_str]:
+        for entry in entries:
             food = entry["food"]
-            calories = _normalize_calories(entry["calories"])
+            calories = normalize_calories(entry["calories"])
             total_calories += calories
-
-            # Pad calories to maintain consistent alignment
-            padded_calories = str(calories).ljust(4)  # Use fixed width of 4 characters
-
+            padded_calories = str(calories).ljust(4)
             print_formatted_text(HTML(f"{padded_calories}cal - <green>{food}</green>"))
 
         calorie_target = cabinet.get("foodlog", "calorie_target")
@@ -309,7 +300,6 @@ def display_daily_calories(target_date: datetime.date = None) -> None:
             cabinet.log("Calorie target not set, using 1750", level="warning")
             calorie_target = 1750
 
-        # Color-code total calories. +- 150 is green, 150-300 is yellow, over 300 is red
         if abs(total_calories - calorie_target) <= 150:
             total_color = "green"
         elif abs(total_calories - calorie_target) <= 300:
@@ -318,7 +308,7 @@ def display_daily_calories(target_date: datetime.date = None) -> None:
             total_color = "red"
 
         submitted_note = ""
-        if is_day_submitted(target_date_str):
+        if store.is_day_submitted(target_date_str):
             submitted_note = " <green>(submitted)</green>"
 
         print_formatted_text(
@@ -340,7 +330,6 @@ def display_daily_calories(target_date: datetime.date = None) -> None:
 
 def get_calories(food_name: str, lookup_data: dict) -> int:
     """get calorie count for a food item, either from lookup or user input."""
-    # Convert food name to lowercase for case-insensitive lookup
     food_name_lower = food_name.lower()
 
     if food_name_lower in lookup_data:
@@ -376,7 +365,6 @@ def query_chatgpt(food_name: str) -> str:
 def classify_food(food_names: list[str]) -> dict[str, str]:
     """Classify multiple food items as 'junk' or 'healthy' using AI."""
 
-    # Create a prompt that lists all foods and asks for classification
     food_list = "\n".join([f"- {food}" for food in food_names])
     prompt = f"""Classify each of these food items as either 'junk' or 'healthy'.
 For each item, output the food name followed by a colon and its classification.
@@ -393,7 +381,6 @@ food3: junk
 
     response = chatgpt.query(prompt)
 
-    # Parse the response into a dictionary
     classifications = {}
     for line in response.split("\n"):
         if ":" in line:
@@ -405,30 +392,33 @@ food3: junk
 
 def show_summary() -> None:
     """Display a summary of the past 7 days of food entries with AI classification."""
-    log_data = load_json(FOOD_LOG_FILE)
-    lookup_data = load_json(FOOD_LOOKUP_FILE)
+    _ensure_migrated()
+    store = get_store()
     today = datetime.date.today()
+    start = (today - datetime.timedelta(days=6)).isoformat()
+    log_data = store.list_days_between(start, today.isoformat())
+    lookup_data = store.get_lookup()
 
     print_formatted_text(
         HTML("<bold><underline>Food Summary (Last 7 Days)</underline></bold>\n")
     )
 
-    # First, collect all unique food items from the past 7 days
     all_foods = set()
-    daily_totals = {}  # Store daily totals for the bar graph
-    daily_healthy = {}  # Store daily healthy calories
-    daily_junk = {}  # Store daily junk calories
+    daily_totals = {}
+    daily_healthy = {}
+    daily_junk = {}
     for i in range(7):
         date = today - datetime.timedelta(days=i)
         date_str = date.isoformat()
         if date_str in log_data:
-            daily_totals[date] = sum(entry["calories"] for entry in log_data[date_str])
+            daily_totals[date] = sum(
+                normalize_calories(entry["calories"]) for entry in log_data[date_str]
+            )
             daily_healthy[date] = 0
             daily_junk[date] = 0
             for entry in log_data[date_str]:
                 all_foods.add(entry["food"])
 
-    # Get classifications for all foods at once
     foods_to_classify = []
     for food in all_foods:
         food_lower = food.lower()
@@ -441,15 +431,9 @@ def show_summary() -> None:
 
     if foods_to_classify:
         classifications = classify_food(foods_to_classify)
-
-        # Update the lookup file with new classifications
         for food, classification in classifications.items():
-            food_lower = food.lower()
-            if food_lower not in lookup_data:
-                lookup_data[food_lower] = {"calories": 0, "type": classification}
-            else:
-                lookup_data[food_lower]["type"] = classification
-        save_json(FOOD_LOOKUP_FILE, lookup_data)
+            store.set_lookup_type(food, classification)
+        lookup_data = store.get_lookup()
     else:
         classifications = {}
 
@@ -457,7 +441,6 @@ def show_summary() -> None:
     healthy_calories = 0
     junk_calories = 0
 
-    # Display entries in reverse chronological order
     for i in range(6, -1, -1):
         date = today - datetime.timedelta(days=i)
         date_str = date.isoformat()
@@ -469,15 +452,11 @@ def show_summary() -> None:
 
             for entry in log_data[date_str]:
                 food = entry["food"]
-                calories = entry["calories"]
+                calories = normalize_calories(entry["calories"])
                 total_calories += calories
 
-                # Get the classification from the lookup file (using lowercase)
                 food_lower = food.lower()
-                if food_lower in lookup_data:
-                    classification = lookup_data[food_lower].get("type", "unknown")
-                else:
-                    classification = "unknown"
+                classification = lookup_data.get(food_lower, {}).get("type", "unknown")
 
                 if classification == "healthy":
                     healthy_calories += calories
@@ -494,7 +473,6 @@ def show_summary() -> None:
                     )
                 )
 
-    # Print summary statistics
     print_formatted_text(HTML("\n<bold>Calorie Summary:</bold>"))
     if total_calories > 0:
         print_formatted_text(
@@ -514,30 +492,23 @@ def show_summary() -> None:
     else:
         print_formatted_text(HTML("  No calories logged in the past 7 days"))
 
-    # Add daily totals bar graph
     print_formatted_text(HTML("\n<bold>Daily Calorie Totals:</bold>"))
 
-    # Find the maximum calories for scaling the bar graph
     max_calories = max(daily_totals.values()) if daily_totals else 0
-    bar_width = 25  # Maximum width of the bar graph in characters
+    bar_width = 25
 
-    # Display bars in reverse chronological order
     for i in range(6, -1, -1):
         date = today - datetime.timedelta(days=i)
         if date in daily_totals:
             total = daily_totals[date]
             healthy = daily_healthy[date]
 
-            # Calculate the scaled bar length based on total calories
             scaled_length = (
                 int((total / max_calories) * bar_width) if max_calories > 0 else 0
             )
-
-            # Calculate the healthy/junk ratio within the scaled length
             healthy_length = int((healthy / total) * scaled_length) if total > 0 else 0
             junk_length = scaled_length - healthy_length
 
-            # Create the bar with both colors
             health_bar = (
                 f'<green>{"█" * healthy_length}</green><red>{"█" * junk_length}</red>'
             )
@@ -568,12 +539,10 @@ def main() -> None:
         display_daily_calories()
         sys.exit(0)
 
-    # Check if --yesterday is present and remove it
     if "--yesterday" in sys.argv:
         is_yesterday = True
         sys.argv.remove("--yesterday")
 
-        # If no other arguments remain, display yesterday's data
         if len(sys.argv) < 2:
             yesterday = datetime.date.today() - datetime.timedelta(days=1)
             display_daily_calories(yesterday)
@@ -587,8 +556,24 @@ def main() -> None:
         count = sync_all_to_grafana()
         print_formatted_text(
             HTML(
-                f"<green>Synced</green> <yellow>{count}</yellow> day(s) from food.json "
-                "to Grafana (Loki)."
+                f"<green>Synced</green> <yellow>{count}</yellow> day(s) from MongoDB "
+                "foodlog to Grafana (Loki)."
+            )
+        )
+        sys.exit(0)
+
+    if sys.argv[1] in ("--migrate", "migrate"):
+        store = get_store()
+        imported = store.migrate_from_json_files(
+            FOOD_LOG_FILE,
+            FOOD_LOOKUP_FILE,
+            FOOD_SUBMITTED_FILE,
+            only_if_empty=False,
+        )
+        print_formatted_text(
+            HTML(
+                f"<green>Imported</green> <yellow>{imported}</yellow> day(s) "
+                "into MongoDB database <yellow>foodlog</yellow>."
             )
         )
         sys.exit(0)
@@ -617,18 +602,13 @@ def main() -> None:
         sys.exit(0)
 
     try:
-        # Join all arguments and split by //
         full_command = " ".join(sys.argv[1:])
         if "//" in full_command:
-            # Split into separate commands and process each one
             commands = [cmd.strip() for cmd in full_command.split("//")]
             for i, cmd in enumerate(commands):
-                # Set a global flag to indicate that this is the last main call
                 globals()["_is_last_main_call"] = i == len(commands) - 1
 
-                # Create new sys.argv for each command
                 cmd_args = cmd.split()
-                # Save original sys.argv and restore it after each command
                 original_argv = sys.argv.copy()
                 sys.argv = [sys.argv[0]] + cmd_args
                 try:
@@ -637,14 +617,13 @@ def main() -> None:
                     sys.argv = original_argv
             return
 
-        # Regular single command processing
         food_name = " ".join(sys.argv[1:-1])
         calories = sys.argv[-1]
 
-        # last arg is a string -> calories not set; get from lookup
         if isinstance(calories, str) and not calories.isnumeric():
             food_name = " ".join(sys.argv[1:])
-            lookup_data = load_json(FOOD_LOOKUP_FILE)
+            _ensure_migrated()
+            lookup_data = get_store().get_lookup()
             calories = get_calories(food_name, lookup_data)
         else:
             calories = int(calories)
@@ -659,25 +638,18 @@ def main() -> None:
 
 def undo_latest_entry() -> None:
     """Remove the latest food entry from today's log."""
-    ensure_log_directory()
-    log_data = load_json(FOOD_LOG_FILE)
+    _ensure_migrated()
+    store = get_store()
     today = datetime.date.today().isoformat()
 
-    if today not in log_data or not log_data[today]:
+    removed_entry = store.pop_latest_entry(today)
+    if not removed_entry:
         print_formatted_text(HTML("<yellow>No entries to undo for today.</yellow>"))
         return
 
-    # Remove the last entry
-    removed_entry = log_data[today].pop()
     food_name = removed_entry["food"]
     calories = removed_entry["calories"]
-
-    # If no entries left for today, remove the day entirely
-    if not log_data[today]:
-        del log_data[today]
-
-    save_json(FOOD_LOG_FILE, log_data)
-    sync_day_to_grafana(today, log_data=log_data)
+    sync_day_to_grafana(today)
     print_formatted_text(
         HTML(f"<green>Removed:</green> {food_name} <yellow>({calories} cal)</yellow>")
     )
@@ -685,8 +657,33 @@ def undo_latest_entry() -> None:
 
 
 def edit_food_json() -> None:
-    """Edit the food.json file."""
-    os.system(f"{cabinet.editor} {FOOD_LOG_FILE}")
+    """Export Mongo days to a temp JSON, edit, re-import."""
+    _ensure_migrated()
+    store = get_store()
+    ensure_log_directory()
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix="-food.json",
+        delete=False,
+        encoding="utf-8",
+    ) as tmp:
+        json.dump(store.export_log_map(), tmp, indent=4)
+        tmp_path = tmp.name
+    os.system(f"{cabinet.editor} {tmp_path}")
+    try:
+        with open(tmp_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        submitted = store.export_submitted_map()
+        store.days.delete_many({})
+        store.replace_all_from_maps(data, submitted_data=submitted)
+        print_formatted_text(
+            HTML("<green>Re-imported</green> edited food log into MongoDB.")
+        )
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
 
 
 if __name__ == "__main__":

--- a/foodlog/main.py
+++ b/foodlog/main.py
@@ -6,6 +6,9 @@ import json
 import sys
 import os
 import datetime
+import socket
+import urllib.error
+import urllib.request
 from tyler_python_helpers import ChatGPT
 from prompt_toolkit import print_formatted_text, HTML
 from cabinet import Cabinet
@@ -17,6 +20,7 @@ chatgpt = ChatGPT()
 LOG_DIR = cabinet.get("path", "cabinet", "log") or os.path.expanduser("~/.cabinet/log")
 FOOD_LOG_FILE = os.path.join(LOG_DIR, "food.json")
 FOOD_LOOKUP_FILE = os.path.join(LOG_DIR, "food_lookup.json")
+FOOD_SUBMITTED_FILE = os.path.join(LOG_DIR, "food_submitted.json")
 
 
 def ensure_log_directory() -> None:
@@ -38,6 +42,161 @@ def save_json(file_path: str, data: dict) -> None:
         json.dump(data, f, indent=4)
 
 
+def _normalize_calories(calories) -> int:
+    """Coerce calorie values (int, numeric str, or nested dict) to int."""
+    if isinstance(calories, dict):
+        return int(calories.get("calories", 0) or 0)
+    if isinstance(calories, str) and calories.isnumeric():
+        return int(calories)
+    return int(calories)
+
+
+def day_total_calories(entries: list) -> int:
+    """Sum calorie counts for a list of food log entries."""
+    total = 0
+    for entry in entries:
+        total += _normalize_calories(entry.get("calories", 0))
+    return total
+
+
+def is_day_submitted(day: str, submitted_data: dict | None = None) -> bool:
+    """Return True if ``foodlog submit`` has been run for ``day`` (ISO date)."""
+    if submitted_data is None:
+        submitted_data = load_json(FOOD_SUBMITTED_FILE)
+    value = submitted_data.get(day)
+    if isinstance(value, dict):
+        return bool(value.get("submitted"))
+    return bool(value)
+
+
+def mark_day_submitted(day: str | None = None) -> str:
+    """
+    Mark a day as submitted so dailystatus skips the foodlog reminder email.
+
+    Returns the ISO date that was marked.
+    """
+    ensure_log_directory()
+    day = day or datetime.date.today().isoformat()
+    submitted_data = load_json(FOOD_SUBMITTED_FILE)
+    submitted_data[day] = {
+        "submitted": True,
+        "submitted_at": datetime.datetime.now().astimezone().isoformat(timespec="seconds"),
+    }
+    save_json(FOOD_SUBMITTED_FILE, submitted_data)
+    return day
+
+
+def _loki_base_url() -> str | None:
+    """Cabinet Loki base URL (no /push), or None if unset."""
+    url = getattr(cabinet, "logging_loki_url", "") or ""
+    url = url.strip().rstrip("/")
+    return url or None
+
+
+def build_daily_grafana_event(
+    day: str,
+    entries: list,
+    submitted: bool,
+    hostname: str | None = None,
+) -> dict:
+    """Build a structured daily snapshot for Loki / Grafana."""
+    return {
+        "type": "daily",
+        "date": day,
+        "total_calories": day_total_calories(entries),
+        "entry_count": len(entries),
+        "submitted": submitted,
+        "hostname": hostname or socket.gethostname(),
+        "foods": [
+            {
+                "food": e.get("food", "unknown"),
+                "calories": _normalize_calories(e.get("calories", 0)),
+            }
+            for e in entries
+        ],
+    }
+
+
+def build_loki_push_body(event: dict, timestamp: datetime.datetime | None = None) -> dict:
+    """Build a Loki push API body for a single foodlog event."""
+    ts = timestamp or datetime.datetime.now(datetime.timezone.utc)
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=datetime.timezone.utc)
+    # Anchor daily snapshots at noon UTC on that calendar day so charts stay stable
+    # when the day is updated throughout local logging.
+    if event.get("type") == "daily" and event.get("date"):
+        try:
+            day = datetime.date.fromisoformat(event["date"])
+            ts = datetime.datetime(
+                day.year, day.month, day.day, 12, 0, 0, tzinfo=datetime.timezone.utc
+            )
+        except ValueError:
+            pass
+    ns = str(int(ts.timestamp() * 1_000_000_000))
+    labels = {
+        "job": "foodlog",
+        "type": str(event.get("type", "daily")),
+        "hostname": str(event.get("hostname") or socket.gethostname()),
+    }
+    return {
+        "streams": [
+            {
+                "stream": labels,
+                "values": [[ns, json.dumps(event, separators=(",", ":"))]],
+            }
+        ]
+    }
+
+
+def push_event_to_loki(event: dict, loki_url: str | None = None) -> bool:
+    """
+    POST a foodlog event to Loki for Grafana.
+
+    Returns True on success. No-op (False) when Loki URL is unset.
+    """
+    base = (loki_url or _loki_base_url() or "").rstrip("/")
+    if not base:
+        return False
+    body = json.dumps(build_loki_push_body(event)).encode("utf-8")
+    req = urllib.request.Request(
+        f"{base}/loki/api/v1/push",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return 200 <= getattr(resp, "status", 200) < 300
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        cabinet.log(f"foodlog Grafana/Loki push failed: {exc}", level="warning")
+        return False
+
+
+def sync_day_to_grafana(day: str | None = None, log_data: dict | None = None) -> bool:
+    """Push one day's totals from flat-file food.json to Loki (existing Grafana)."""
+    day = day or datetime.date.today().isoformat()
+    if log_data is None:
+        log_data = load_json(FOOD_LOG_FILE)
+    entries = log_data.get(day, [])
+    event = build_daily_grafana_event(
+        day,
+        entries,
+        submitted=is_day_submitted(day),
+    )
+    return push_event_to_loki(event)
+
+
+def sync_all_to_grafana(log_data: dict | None = None) -> int:
+    """Backfill all days in food.json to Loki. Returns number of successful pushes."""
+    if log_data is None:
+        log_data = load_json(FOOD_LOG_FILE)
+    ok = 0
+    for day in sorted(log_data.keys()):
+        if sync_day_to_grafana(day, log_data=log_data):
+            ok += 1
+    return ok
+
+
 def log_food(food_name: str, calories: int, is_yesterday: bool = False) -> None:
     """log food entry for today's date."""
     ensure_log_directory()
@@ -50,11 +209,7 @@ def log_food(food_name: str, calories: int, is_yesterday: bool = False) -> None:
     if today not in log_data:
         log_data[today] = []
 
-    # Ensure calories is an integer
-    if isinstance(calories, dict):
-        calories = calories.get("calories", 0)
-    elif isinstance(calories, str) and calories.isnumeric():
-        calories = int(calories)
+    calories = _normalize_calories(calories)
 
     # Store food name in lowercase for consistency
     food_name_lower = food_name.lower()
@@ -63,6 +218,7 @@ def log_food(food_name: str, calories: int, is_yesterday: bool = False) -> None:
     print_formatted_text(
         HTML(f"<green>Logged:</green> {food_name} <yellow>({calories} cal)</yellow>")
     )
+    sync_day_to_grafana(today, log_data=log_data)
 
     if globals().get("_is_last_main_call", False):
         display_daily_calories()
@@ -140,10 +296,7 @@ def display_daily_calories(target_date: datetime.date = None) -> None:
         # Find the maximum length of calories for alignment
         for entry in log_data[target_date_str]:
             food = entry["food"]
-            calories = entry["calories"]
-            # Ensure calories is an integer
-            if isinstance(calories, dict):
-                calories = calories.get("calories", 0)
+            calories = _normalize_calories(entry["calories"])
             total_calories += calories
 
             # Pad calories to maintain consistent alignment
@@ -164,9 +317,14 @@ def display_daily_calories(target_date: datetime.date = None) -> None:
         else:
             total_color = "red"
 
+        submitted_note = ""
+        if is_day_submitted(target_date_str):
+            submitted_note = " <green>(submitted)</green>"
+
         print_formatted_text(
             HTML(
                 f"\n<bold>Total:</bold> <{total_color}>{total_calories}</{total_color}>"
+                f"{submitted_note}"
             )
         )
     else:
@@ -389,6 +547,19 @@ def show_summary() -> None:
             )
 
 
+def submit_day(day: str | None = None) -> None:
+    """Mark the day submitted and sync the snapshot to Grafana/Loki."""
+    day = mark_day_submitted(day)
+    sync_day_to_grafana(day)
+    print_formatted_text(
+        HTML(
+            f"<green>Submitted</green> food log for <yellow>{day}</yellow>. "
+            "Daily status will skip the foodlog reminder."
+        )
+    )
+    display_daily_calories(datetime.date.fromisoformat(day))
+
+
 def main() -> None:
     """parse command-line arguments and log food entry."""
     is_yesterday = False
@@ -407,6 +578,20 @@ def main() -> None:
             yesterday = datetime.date.today() - datetime.timedelta(days=1)
             display_daily_calories(yesterday)
             sys.exit(0)
+
+    if sys.argv[1] in ("submit", "--submit"):
+        submit_day()
+        sys.exit(0)
+
+    if sys.argv[1] in ("--sync-grafana", "sync-grafana"):
+        count = sync_all_to_grafana()
+        print_formatted_text(
+            HTML(
+                f"<green>Synced</green> <yellow>{count}</yellow> day(s) from food.json "
+                "to Grafana (Loki)."
+            )
+        )
+        sys.exit(0)
 
     if sys.argv[1] == "--edit":
         edit_food_json()
@@ -492,6 +677,7 @@ def undo_latest_entry() -> None:
         del log_data[today]
 
     save_json(FOOD_LOG_FILE, log_data)
+    sync_day_to_grafana(today, log_data=log_data)
     print_formatted_text(
         HTML(f"<green>Removed:</green> {food_name} <yellow>({calories} cal)</yellow>")
     )

--- a/foodlog/store.py
+++ b/foodlog/store.py
@@ -1,0 +1,317 @@
+"""MongoDB store for foodlog (peer DB to Cabinet on the same server)."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+from typing import Any
+
+from pymongo import ASCENDING, MongoClient
+from pymongo.collection import Collection
+from pymongo.database import Database
+
+FOODLOG_DB_NAME = "foodlog"
+DAYS_COLLECTION = "days"
+LOOKUP_COLLECTION = "lookup"
+
+
+def _noon_utc(day: str) -> datetime.datetime:
+    d = datetime.date.fromisoformat(day)
+    return datetime.datetime(d.year, d.month, d.day, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+def normalize_calories(calories: Any) -> int:
+    """Coerce calorie values (int, numeric str, or nested dict) to int."""
+    if isinstance(calories, dict):
+        return int(calories.get("calories", 0) or 0)
+    if isinstance(calories, str) and calories.isnumeric():
+        return int(calories)
+    return int(calories)
+
+
+def day_total_calories(entries: list) -> int:
+    """Sum calorie counts for a list of food log entries."""
+    return sum(normalize_calories(e.get("calories", 0)) for e in entries)
+
+
+def is_submitted_value(value: Any) -> bool:
+    """Interpret submitted flag from bool or ``{\"submitted\": bool}`` shapes."""
+    if isinstance(value, dict):
+        return bool(value.get("submitted"))
+    return bool(value)
+
+
+class FoodlogStore:
+    """
+    Source of truth for foodlog on the same MongoDB server as Cabinet.
+
+    Database: ``foodlog`` (peer to Cabinet's ``cabinet`` DB).
+    Collections: ``days`` (one doc per ISO date), ``lookup`` (food calorie/type).
+    """
+
+    def __init__(
+        self,
+        connection_string: str | None = None,
+        db_name: str = FOODLOG_DB_NAME,
+        client: MongoClient | None = None,
+    ) -> None:
+        if client is not None:
+            self._client = client
+            self._owns_client = False
+        else:
+            uri = (connection_string or os.environ.get("FOODLOG_MONGO_URI") or "").strip()
+            if not uri:
+                # Same server as Cabinet; Cabinet config is the usual source.
+                try:
+                    from cabinet import Cabinet
+
+                    cab = Cabinet()
+                    uri = (getattr(cab, "mongodb_connection_string", None) or "").strip()
+                except Exception:  # pylint: disable=broad-exception-caught
+                    uri = ""
+            if not uri:
+                uri = "mongodb://localhost:27017/"
+            self._client = MongoClient(uri, serverSelectionTimeoutMS=5000)
+            self._owns_client = True
+        self.db: Database = self._client[db_name]
+        self.days: Collection = self.db[DAYS_COLLECTION]
+        self.lookup: Collection = self.db[LOOKUP_COLLECTION]
+        self._ensure_indexes()
+
+    def _ensure_indexes(self) -> None:
+        self.days.create_index([("date", ASCENDING)], unique=True)
+        self.days.create_index([("date_time", ASCENDING)])
+        self.lookup.create_index([("food", ASCENDING)], unique=True)
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def ping(self) -> bool:
+        self._client.admin.command("ping")
+        return True
+
+    def get_day(self, day: str) -> dict | None:
+        return self.days.find_one({"_id": day})
+
+    def get_entries(self, day: str) -> list[dict]:
+        doc = self.get_day(day)
+        if not doc:
+            return []
+        return list(doc.get("entries") or [])
+
+    def list_days_between(self, start: str, end: str) -> dict[str, list]:
+        """Return ``{iso_date: entries}`` for dates in ``[start, end]`` inclusive."""
+        cursor = self.days.find(
+            {"_id": {"$gte": start, "$lte": end}},
+            projection={"entries": 1},
+        )
+        return {doc["_id"]: list(doc.get("entries") or []) for doc in cursor}
+
+    def all_days_map(self) -> dict[str, list]:
+        """Legacy food.json-shaped map of all days → entries."""
+        out: dict[str, list] = {}
+        for doc in self.days.find({}, projection={"entries": 1}):
+            out[doc["_id"]] = list(doc.get("entries") or [])
+        return out
+
+    def is_day_submitted(self, day: str) -> bool:
+        doc = self.get_day(day)
+        if not doc:
+            return False
+        return bool(doc.get("submitted"))
+
+    def _write_day(
+        self,
+        day: str,
+        entries: list[dict],
+        *,
+        submitted: bool | None = None,
+        submitted_at: str | None = None,
+    ) -> dict:
+        existing = self.get_day(day)
+        if submitted is None:
+            submitted = bool(existing.get("submitted")) if existing else False
+        if submitted_at is None and existing:
+            submitted_at = existing.get("submitted_at")
+        now = datetime.datetime.now(datetime.timezone.utc)
+        normalized = [
+            {
+                "food": str(e.get("food", "unknown")).lower(),
+                "calories": normalize_calories(e.get("calories", 0)),
+            }
+            for e in entries
+        ]
+        doc = {
+            "_id": day,
+            "date": day,
+            "date_time": _noon_utc(day),
+            "entries": normalized,
+            "total_calories": day_total_calories(normalized),
+            "entry_count": len(normalized),
+            "submitted": submitted,
+            "submitted_at": submitted_at,
+            "updated_at": now,
+        }
+        self.days.replace_one({"_id": day}, doc, upsert=True)
+        return doc
+
+    def append_entry(self, day: str, food: str, calories: int) -> dict:
+        entries = self.get_entries(day)
+        entries.append({"food": food.lower(), "calories": normalize_calories(calories)})
+        return self._write_day(day, entries)
+
+    def pop_latest_entry(self, day: str) -> dict | None:
+        entries = self.get_entries(day)
+        if not entries:
+            return None
+        removed = entries.pop()
+        if entries:
+            self._write_day(day, entries)
+        else:
+            self.days.delete_one({"_id": day})
+        return removed
+
+    def mark_submitted(self, day: str | None = None) -> str:
+        day = day or datetime.date.today().isoformat()
+        entries = self.get_entries(day)
+        submitted_at = datetime.datetime.now().astimezone().isoformat(timespec="seconds")
+        self._write_day(day, entries, submitted=True, submitted_at=submitted_at)
+        return day
+
+    def get_lookup(self) -> dict[str, dict]:
+        """food.json-lookup shaped dict keyed by lowercase food name."""
+        out: dict[str, dict] = {}
+        for doc in self.lookup.find():
+            food = doc.get("food") or doc.get("_id")
+            out[str(food).lower()] = {
+                "calories": normalize_calories(doc.get("calories", 0)),
+                "type": doc.get("type", "unknown"),
+            }
+        return out
+
+    def upsert_lookup(
+        self, food: str, calories: int, food_type: str | None = None
+    ) -> None:
+        food_l = food.lower()
+        existing = self.lookup.find_one({"_id": food_l})
+        doc = {
+            "_id": food_l,
+            "food": food_l,
+            "calories": normalize_calories(calories),
+            "type": food_type
+            or (existing.get("type") if existing else None)
+            or "unknown",
+        }
+        self.lookup.replace_one({"_id": food_l}, doc, upsert=True)
+
+    def set_lookup_type(self, food: str, food_type: str) -> None:
+        food_l = food.lower()
+        existing = self.lookup.find_one({"_id": food_l}) or {
+            "_id": food_l,
+            "food": food_l,
+            "calories": 0,
+        }
+        existing["type"] = food_type
+        existing["food"] = food_l
+        self.lookup.replace_one({"_id": food_l}, existing, upsert=True)
+
+    def replace_all_from_maps(
+        self,
+        log_data: dict,
+        lookup_data: dict | None = None,
+        submitted_data: dict | None = None,
+    ) -> int:
+        """Import food.json / food_lookup.json / food_submitted.json shaped maps."""
+        submitted_data = submitted_data or {}
+        count = 0
+        for day, entries in log_data.items():
+            if not isinstance(entries, list):
+                continue
+            sub = submitted_data.get(day)
+            submitted = is_submitted_value(sub)
+            submitted_at = None
+            if isinstance(sub, dict):
+                submitted_at = sub.get("submitted_at")
+            self._write_day(
+                day,
+                entries,
+                submitted=submitted,
+                submitted_at=submitted_at,
+            )
+            count += 1
+        if lookup_data:
+            for food, meta in lookup_data.items():
+                if not isinstance(meta, dict):
+                    continue
+                self.upsert_lookup(
+                    food,
+                    meta.get("calories", 0),
+                    food_type=meta.get("type", "unknown"),
+                )
+        # Submitted-only days with no entries
+        for day, sub in submitted_data.items():
+            if self.get_day(day):
+                continue
+            if is_submitted_value(sub):
+                submitted_at = sub.get("submitted_at") if isinstance(sub, dict) else None
+                self._write_day(day, [], submitted=True, submitted_at=submitted_at)
+                count += 1
+        return count
+
+    def migrate_from_json_files(
+        self,
+        food_log_file: str,
+        food_lookup_file: str,
+        food_submitted_file: str,
+        *,
+        only_if_empty: bool = True,
+    ) -> int:
+        """Import flat files into Mongo. Returns days imported (0 if skipped)."""
+        if only_if_empty and self.days.estimated_document_count() > 0:
+            return 0
+
+        def _load(path: str) -> dict:
+            if not os.path.exists(path):
+                return {}
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+
+        return self.replace_all_from_maps(
+            _load(food_log_file),
+            _load(food_lookup_file),
+            _load(food_submitted_file),
+        )
+
+    def export_log_map(self) -> dict:
+        return self.all_days_map()
+
+    def export_lookup_map(self) -> dict:
+        return self.get_lookup()
+
+    def export_submitted_map(self) -> dict:
+        out: dict = {}
+        for doc in self.days.find({"submitted": True}):
+            out[doc["_id"]] = {
+                "submitted": True,
+                "submitted_at": doc.get("submitted_at"),
+            }
+        return out
+
+
+_STORE: FoodlogStore | None = None
+
+
+def get_store() -> FoodlogStore:
+    """Process-wide FoodlogStore (lazy)."""
+    global _STORE  # pylint: disable=global-statement
+    if _STORE is None:
+        _STORE = FoodlogStore()
+    return _STORE
+
+
+def reset_store_for_tests(store: FoodlogStore | None = None) -> None:
+    """Test helper to inject/clear the singleton."""
+    global _STORE  # pylint: disable=global-statement
+    _STORE = store

--- a/foodlog/test_foodlog.py
+++ b/foodlog/test_foodlog.py
@@ -1,13 +1,13 @@
-"""Tests for foodlog 2.0 helpers (TJW-245)."""
+"""Tests for foodlog 2.0 helpers and Mongo store (TJW-245)."""
 
 import datetime
 import json
-import tempfile
 import unittest
-from pathlib import Path
 from unittest import mock
 
 import main as foodlog
+from store import FoodlogStore, day_total_calories, is_submitted_value
+from pymongo import MongoClient
 
 
 class FoodlogHelpersTests(unittest.TestCase):
@@ -16,21 +16,13 @@ class FoodlogHelpersTests(unittest.TestCase):
             {"food": "apple", "calories": 50},
             {"food": "weird", "calories": {"calories": 100}},
         ]
-        self.assertEqual(foodlog.day_total_calories(entries), 150)
+        self.assertEqual(day_total_calories(entries), 150)
 
     def test_is_day_submitted_bool_and_dict(self):
-        self.assertFalse(foodlog.is_day_submitted("2026-07-20", {}))
-        self.assertTrue(foodlog.is_day_submitted("2026-07-20", {"2026-07-20": True}))
-        self.assertTrue(
-            foodlog.is_day_submitted(
-                "2026-07-20", {"2026-07-20": {"submitted": True}}
-            )
-        )
-        self.assertFalse(
-            foodlog.is_day_submitted(
-                "2026-07-20", {"2026-07-20": {"submitted": False}}
-            )
-        )
+        self.assertFalse(is_submitted_value(None))
+        self.assertTrue(is_submitted_value(True))
+        self.assertTrue(is_submitted_value({"submitted": True}))
+        self.assertFalse(is_submitted_value({"submitted": False}))
 
     def test_build_daily_grafana_event(self):
         event = foodlog.build_daily_grafana_event(
@@ -63,20 +55,11 @@ class FoodlogHelpersTests(unittest.TestCase):
         payload = json.loads(stream["values"][0][1])
         self.assertEqual(payload["total_calories"], 100)
 
-    def test_mark_day_submitted_writes_flat_file(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            submitted_path = Path(tmp) / "food_submitted.json"
-            with mock.patch.object(foodlog, "FOOD_SUBMITTED_FILE", str(submitted_path)):
-                with mock.patch.object(foodlog, "LOG_DIR", tmp):
-                    day = foodlog.mark_day_submitted("2026-07-20")
-            self.assertEqual(day, "2026-07-20")
-            data = json.loads(submitted_path.read_text(encoding="utf-8"))
-            self.assertTrue(data["2026-07-20"]["submitted"])
-            self.assertIn("submitted_at", data["2026-07-20"])
-
     def test_push_event_to_loki_noop_without_url(self):
         with mock.patch.object(foodlog, "_loki_base_url", return_value=None):
-            self.assertFalse(foodlog.push_event_to_loki({"type": "daily", "date": "2026-07-20"}))
+            self.assertFalse(
+                foodlog.push_event_to_loki({"type": "daily", "date": "2026-07-20"})
+            )
 
     def test_push_event_to_loki_posts(self):
         class FakeResp:
@@ -102,6 +85,47 @@ class FoodlogHelpersTests(unittest.TestCase):
         req = urlopen.call_args[0][0]
         self.assertEqual(req.full_url, "http://loki.example:3100/loki/api/v1/push")
         self.assertEqual(req.get_method(), "POST")
+
+
+class FoodlogStoreMongoTests(unittest.TestCase):
+    """Integration tests against local Mongo (skips if unavailable)."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            client = MongoClient("mongodb://localhost:27017/", serverSelectionTimeoutMS=2000)
+            client.admin.command("ping")
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            raise unittest.SkipTest(f"MongoDB not available: {exc}") from exc
+        cls.client = client
+        cls.db_name = "foodlog_test_tjw245"
+
+    def setUp(self):
+        self.client.drop_database(self.db_name)
+        self.store = FoodlogStore(client=self.client, db_name=self.db_name)
+
+    def tearDown(self):
+        self.client.drop_database(self.db_name)
+
+    def test_append_submit_and_totals(self):
+        self.store.append_entry("2026-07-20", "Huel", 400)
+        self.store.append_entry("2026-07-20", "apple", 50)
+        doc = self.store.get_day("2026-07-20")
+        self.assertEqual(doc["total_calories"], 450)
+        self.assertEqual(doc["entry_count"], 2)
+        self.assertFalse(doc["submitted"])
+        self.store.mark_submitted("2026-07-20")
+        self.assertTrue(self.store.is_day_submitted("2026-07-20"))
+
+    def test_import_from_maps(self):
+        n = self.store.replace_all_from_maps(
+            {"2026-07-19": [{"food": "tea", "calories": 5}]},
+            {"tea": {"calories": 5, "type": "healthy"}},
+            {"2026-07-19": {"submitted": True, "submitted_at": "x"}},
+        )
+        self.assertEqual(n, 1)
+        self.assertTrue(self.store.is_day_submitted("2026-07-19"))
+        self.assertEqual(self.store.get_lookup()["tea"]["type"], "healthy")
 
 
 if __name__ == "__main__":

--- a/foodlog/test_foodlog.py
+++ b/foodlog/test_foodlog.py
@@ -1,0 +1,108 @@
+"""Tests for foodlog 2.0 helpers (TJW-245)."""
+
+import datetime
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import main as foodlog
+
+
+class FoodlogHelpersTests(unittest.TestCase):
+    def test_day_total_calories_normalizes_nested(self):
+        entries = [
+            {"food": "apple", "calories": 50},
+            {"food": "weird", "calories": {"calories": 100}},
+        ]
+        self.assertEqual(foodlog.day_total_calories(entries), 150)
+
+    def test_is_day_submitted_bool_and_dict(self):
+        self.assertFalse(foodlog.is_day_submitted("2026-07-20", {}))
+        self.assertTrue(foodlog.is_day_submitted("2026-07-20", {"2026-07-20": True}))
+        self.assertTrue(
+            foodlog.is_day_submitted(
+                "2026-07-20", {"2026-07-20": {"submitted": True}}
+            )
+        )
+        self.assertFalse(
+            foodlog.is_day_submitted(
+                "2026-07-20", {"2026-07-20": {"submitted": False}}
+            )
+        )
+
+    def test_build_daily_grafana_event(self):
+        event = foodlog.build_daily_grafana_event(
+            "2026-07-20",
+            [{"food": "huel", "calories": 400}],
+            submitted=True,
+            hostname="test-host",
+        )
+        self.assertEqual(event["type"], "daily")
+        self.assertEqual(event["date"], "2026-07-20")
+        self.assertEqual(event["total_calories"], 400)
+        self.assertEqual(event["entry_count"], 1)
+        self.assertTrue(event["submitted"])
+        self.assertEqual(event["hostname"], "test-host")
+
+    def test_build_loki_push_body_anchors_daily_at_noon_utc(self):
+        event = {
+            "type": "daily",
+            "date": "2026-07-20",
+            "total_calories": 100,
+            "hostname": "h",
+        }
+        body = foodlog.build_loki_push_body(event)
+        stream = body["streams"][0]
+        self.assertEqual(stream["stream"]["job"], "foodlog")
+        self.assertEqual(stream["stream"]["type"], "daily")
+        ns = int(stream["values"][0][0])
+        ts = datetime.datetime.fromtimestamp(ns / 1_000_000_000, tz=datetime.timezone.utc)
+        self.assertEqual(ts, datetime.datetime(2026, 7, 20, 12, 0, tzinfo=datetime.timezone.utc))
+        payload = json.loads(stream["values"][0][1])
+        self.assertEqual(payload["total_calories"], 100)
+
+    def test_mark_day_submitted_writes_flat_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            submitted_path = Path(tmp) / "food_submitted.json"
+            with mock.patch.object(foodlog, "FOOD_SUBMITTED_FILE", str(submitted_path)):
+                with mock.patch.object(foodlog, "LOG_DIR", tmp):
+                    day = foodlog.mark_day_submitted("2026-07-20")
+            self.assertEqual(day, "2026-07-20")
+            data = json.loads(submitted_path.read_text(encoding="utf-8"))
+            self.assertTrue(data["2026-07-20"]["submitted"])
+            self.assertIn("submitted_at", data["2026-07-20"])
+
+    def test_push_event_to_loki_noop_without_url(self):
+        with mock.patch.object(foodlog, "_loki_base_url", return_value=None):
+            self.assertFalse(foodlog.push_event_to_loki({"type": "daily", "date": "2026-07-20"}))
+
+    def test_push_event_to_loki_posts(self):
+        class FakeResp:
+            status = 204
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        with mock.patch("urllib.request.urlopen", return_value=FakeResp()) as urlopen:
+            ok = foodlog.push_event_to_loki(
+                {
+                    "type": "daily",
+                    "date": "2026-07-20",
+                    "total_calories": 10,
+                    "hostname": "h",
+                },
+                loki_url="http://loki.example:3100",
+            )
+        self.assertTrue(ok)
+        req = urlopen.call_args[0][0]
+        self.assertEqual(req.full_url, "http://loki.example:3100/loki/api/v1/push")
+        self.assertEqual(req.get_method(), "POST")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Keep flat-file `food.json` as source of truth; push daily calorie snapshots to Loki (`job=foodlog`) on log/undo/submit so existing Grafana can chart patterns over time.
- Add `foodlog submit` / `foodlog --submit` (writes `food_submitted.json`) and `foodlog --sync-grafana` for history backfill.
- Dailystatus sends the foodlog reminder only when today is not submitted; still shows calorie totals when food was logged.

## Test plan
- [ ] `cd foodlog && python3 -m unittest test_foodlog.py -v`
- [ ] `cd dailystatus && python3 -m unittest test_foodlog_submit.py -v`
- [ ] `foodlog "test apple" 50` then confirm Loki/Grafana updates (Cabinet `logging.loki_url` set)
- [ ] `foodlog submit` then dry-run dailystatus and confirm no food reminder email
- [ ] Without submit, confirm reminder still fires even if food was logged