### PR TITLE
TJW-328: Identify and replace unplayable Spotify tracks

### DIFF
--- a/spotify_analytics/README.md
+++ b/spotify_analytics/README.md
@@ -30,7 +30,14 @@ python3 replace_unplayable.py --limit 3 --yes
 python3 replace_unplayable.py --limit 3 --yes --update-spotify
 ```
 
-Duration matching: Spotify `duration_ms` vs yt-dlp `ytsearchN` results; default tolerance ±15s (`--tolerance`). Spotify cannot add local files via API — `--update-spotify` only removes the unplayable URI once a local copy exists.
+Matching rules:
+- Skip placeholder titles/artists (`(unknown)`, `N/A`, empty, etc.)
+- YouTube hit must include the Spotify artist in the video title or channel
+- Prefer closest duration within ±15s (`--tolerance`), penalize clean/censored/live/cover/karaoke
+- If Spotify marks the track explicit, further penalize clean/censored uploads
+- Search tries `"Artist" Title` before looser queries (avoids same-title wrong-artist hits)
+
+Spotify cannot add local files via API — `--update-spotify` only removes the unplayable URI once a local copy exists.
 
 ## dependencies
 - [Spotify API access](https://stevesie.com/docs/pages/spotify-client-id-secret-developer-api)

--- a/spotify_analytics/README.md
+++ b/spotify_analytics/README.md
@@ -6,6 +6,16 @@ Unplayable detection:
 - A track is reported when the playlist item's `track` is `null`, or when `is_playable` is explicitly `false`.
 - Empty `available_markets` alone is **not** treated as unplayable (that field is unreliable without a market).
 - Unplayable tracks are logged as warnings; they are not removed automatically.
+- The daily run also writes a deduped list to `spotify unplayable.json` next to `spotify songs.json` (under Cabinet `path.log`).
+
+List / refresh unplayable tracks (Phase 1 of auto-replace with local copies):
+
+```bash
+python3 identify_unplayable.py              # read daily spotify unplayable.json
+python3 identify_unplayable.py --live       # scan playlists via Spotipy now
+python3 identify_unplayable.py --live --json
+python3 identify_unplayable.py --live --write ~/syncthing/log/spotify\ unplayable.json
+```
 
 ## dependencies
 - [Spotify API access](https://stevesie.com/docs/pages/spotify-client-id-secret-developer-api)

--- a/spotify_analytics/README.md
+++ b/spotify_analytics/README.md
@@ -20,7 +20,7 @@ python3 identify_unplayable.py --live --write ~/syncthing/log/spotify\ unplayabl
 Replace with local YouTube audio (Phase 2 — prefers duration-matched uploads, not long music videos):
 
 ```bash
-# Preview selection only (no download)
+# Preview selection only (no download) — Tyler Radio only by default
 python3 replace_unplayable.py --dry-run --limit 5
 
 # Download into ~/syncthing/music via music-stack `mp3` (beets/Navidrome path)
@@ -28,9 +28,13 @@ python3 replace_unplayable.py --limit 3 --yes
 
 # After download, also remove greyed-out Spotify URIs from playlists
 python3 replace_unplayable.py --limit 3 --yes --update-spotify
+
+# Include Removed / other playlists (not just Tyler Radio)
+python3 replace_unplayable.py --all-playlists --dry-run --limit 5
 ```
 
 Matching rules:
+- **Default scope: Tyler Radio only** (first Cabinet `spotipy.playlists` entry). Use `--all-playlists` or `--playlist NAME` to change.
 - Skip placeholder titles/artists (`(unknown)`, `N/A`, empty, etc.)
 - YouTube hit must include the Spotify artist in the video title or channel
 - Prefer closest duration within ±15s (`--tolerance`), penalize clean/censored/live/cover/karaoke

--- a/spotify_analytics/README.md
+++ b/spotify_analytics/README.md
@@ -8,7 +8,7 @@ Unplayable detection:
 - Unplayable tracks are logged as warnings; they are not removed automatically.
 - The daily run also writes a deduped list to `spotify unplayable.json` next to `spotify songs.json` (under Cabinet `path.log`).
 
-List / refresh unplayable tracks (Phase 1 of auto-replace with local copies):
+List / refresh unplayable tracks (Phase 1):
 
 ```bash
 python3 identify_unplayable.py              # read daily spotify unplayable.json
@@ -16,6 +16,21 @@ python3 identify_unplayable.py --live       # scan playlists via Spotipy now
 python3 identify_unplayable.py --live --json
 python3 identify_unplayable.py --live --write ~/syncthing/log/spotify\ unplayable.json
 ```
+
+Replace with local YouTube audio (Phase 2 — prefers duration-matched uploads, not long music videos):
+
+```bash
+# Preview selection only (no download)
+python3 replace_unplayable.py --dry-run --limit 5
+
+# Download into ~/syncthing/music via music-stack `mp3` (beets/Navidrome path)
+python3 replace_unplayable.py --limit 3 --yes
+
+# After download, also remove greyed-out Spotify URIs from playlists
+python3 replace_unplayable.py --limit 3 --yes --update-spotify
+```
+
+Duration matching: Spotify `duration_ms` vs yt-dlp `ytsearchN` results; default tolerance ±15s (`--tolerance`). Spotify cannot add local files via API — `--update-spotify` only removes the unplayable URI once a local copy exists.
 
 ## dependencies
 - [Spotify API access](https://stevesie.com/docs/pages/spotify-client-id-secret-developer-api)

--- a/spotify_analytics/README.md
+++ b/spotify_analytics/README.md
@@ -6,15 +6,16 @@ Unplayable detection:
 - A track is reported when the playlist item's `track` is `null`, or when `is_playable` is explicitly `false`.
 - Empty `available_markets` alone is **not** treated as unplayable (that field is unreliable without a market).
 - Unplayable tracks are logged as warnings; they are not removed automatically.
-- The daily run also writes a deduped list to `spotify unplayable.json` next to `spotify songs.json` (under Cabinet `path.log`).
+- `spotify unplayable.json` (next to `spotify songs.json`) lists **Tyler Radio only** (first Cabinet `spotipy.playlists` entry). Other playlists are still warned about in logs.
 
 List / refresh unplayable tracks (Phase 1):
 
 ```bash
 python3 identify_unplayable.py              # read daily spotify unplayable.json
-python3 identify_unplayable.py --live       # scan playlists via Spotipy now
+python3 identify_unplayable.py --live       # scan Tyler Radio via Spotipy
 python3 identify_unplayable.py --live --json
 python3 identify_unplayable.py --live --write ~/syncthing/log/spotify\ unplayable.json
+python3 identify_unplayable.py --live --all-playlists   # include Removed / genres
 ```
 
 Replace with local YouTube audio (Phase 2 — prefers duration-matched uploads, not long music videos):

--- a/spotify_analytics/identify_unplayable.py
+++ b/spotify_analytics/identify_unplayable.py
@@ -101,7 +101,25 @@ def _merge_records(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     return list(by_key.values())
 
 
-def scan_live(cab: Cabinet) -> List[Dict[str, Any]]:
+def primary_playlist_name(cab: Cabinet) -> str:
+    """First configured spotipy playlist label (Tyler Radio in the usual setup)."""
+    for entry in cab.get("spotipy", "playlists") or []:
+        if isinstance(entry, str) and "," in entry:
+            return entry.split(",", 1)[1].strip() or "Tyler Radio"
+    return "Tyler Radio"
+
+
+def scan_live(
+    cab: Cabinet,
+    *,
+    playlist_filter: Optional[str] = None,
+    all_playlists: bool = False,
+) -> List[Dict[str, Any]]:
+    """Scan playlists for unplayable tracks.
+
+    Default: only the primary playlist (Tyler Radio). Pass all_playlists=True
+    or playlist_filter to change scope.
+    """
     client_id = cab.get("spotipy", "client_id")
     client_secret = cab.get("spotipy", "client_secret")
     playlists = cab.get("spotipy", "playlists") or []
@@ -109,6 +127,13 @@ def scan_live(cab: Cabinet) -> List[Dict[str, Any]]:
         raise RuntimeError("Missing spotipy.client_id / spotipy.client_secret in Cabinet")
     if not playlists:
         raise RuntimeError("Missing spotipy.playlists in Cabinet")
+
+    if all_playlists:
+        wanted: Optional[str] = None
+    elif playlist_filter is not None:
+        wanted = playlist_filter.strip() or None
+    else:
+        wanted = primary_playlist_name(cab)
 
     sp = spotipy.Spotify(
         client_credentials_manager=SpotifyClientCredentials(
@@ -118,12 +143,16 @@ def scan_live(cab: Cabinet) -> List[Dict[str, Any]]:
     )
 
     found: List[Dict[str, Any]] = []
+    scanned = 0
     for entry in playlists:
         if not isinstance(entry, str) or "," not in entry:
             continue
         playlist_id, playlist_name = entry.split(",", 1)
         playlist_id = playlist_id.strip()
         playlist_name = playlist_name.strip()
+        if wanted and playlist_name.lower() != wanted.lower():
+            continue
+        scanned += 1
         results = sp.playlist_items(playlist_id, market=MARKET)
         while results:
             for item in results.get("items") or []:
@@ -142,6 +171,9 @@ def scan_live(cab: Cabinet) -> List[Dict[str, Any]]:
             if not results.get("next"):
                 break
             results = sp.next(results)
+
+    if wanted and scanned == 0:
+        raise RuntimeError(f"No configured playlist matched {wanted!r}")
 
     return _merge_records(found)
 
@@ -173,7 +205,22 @@ def main() -> int:
     parser.add_argument(
         "--live",
         action="store_true",
-        help="Scan playlists via Spotipy instead of reading the daily JSON file",
+        help="Scan Spotify via Spotipy instead of reading the daily JSON file",
+    )
+    parser.add_argument(
+        "--playlist",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help=(
+            "With --live: only scan this playlist "
+            "(default: first Cabinet spotipy playlist, usually Tyler Radio)"
+        ),
+    )
+    parser.add_argument(
+        "--all-playlists",
+        action="store_true",
+        help="With --live: scan every configured playlist (including Removed)",
     )
     parser.add_argument(
         "--json-file",
@@ -198,7 +245,11 @@ def main() -> int:
     cab = Cabinet()
     try:
         if args.live:
-            rows = scan_live(cab)
+            rows = scan_live(
+                cab,
+                playlist_filter=args.playlist,
+                all_playlists=args.all_playlists,
+            )
         else:
             path = Path(args.json_file) if args.json_file else default_unplayable_path(cab)
             try:

--- a/spotify_analytics/identify_unplayable.py
+++ b/spotify_analytics/identify_unplayable.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+Identify Spotify tracks that are unplayable in the US market.
+
+Default: read `spotify unplayable.json` written by the daily spotify_analytics run.
+Use --live to scan configured playlists via Spotipy (market=US / is_playable).
+
+Output is suitable as input for replacing unplayable tracks with local copies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import spotipy
+from cabinet import Cabinet
+from spotipy.oauth2 import SpotifyClientCredentials
+
+MARKET = "US"
+DEFAULT_FILENAME = "spotify unplayable.json"
+
+
+def default_unplayable_path(cab: Cabinet) -> Path:
+    log_path = cab.get("path", "log") or str(Path.home())
+    return Path(log_path) / DEFAULT_FILENAME
+
+
+def load_from_file(path: Path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path}")
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError(f"Expected a JSON array in {path}")
+    return [row for row in data if isinstance(row, dict)]
+
+
+def _track_record(
+    playlist_name: str,
+    track: Optional[Dict[str, Any]],
+    reason: str,
+) -> Dict[str, Any]:
+    if not track:
+        return {
+            "name": "",
+            "artist": "",
+            "url": "",
+            "reason": reason,
+            "playlists": [playlist_name] if playlist_name else [],
+        }
+
+    artists = track.get("artists") or []
+    artist = (artists[0].get("name") or "") if artists else ""
+    name = track.get("name") or "(unknown)"
+    external_urls = track.get("external_urls") or {}
+    url = external_urls.get("spotify") or track.get("uri") or track.get("id") or ""
+    restrictions = track.get("restrictions") or {}
+    restriction_reason = restrictions.get("reason")
+    detail = reason
+    if restriction_reason:
+        detail = f"{reason}; restrictions.reason={restriction_reason}"
+    return {
+        "name": name,
+        "artist": artist,
+        "url": url,
+        "reason": detail,
+        "playlists": [playlist_name] if playlist_name else [],
+    }
+
+
+def _merge_records(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    by_key: Dict[str, Dict[str, Any]] = {}
+    for record in records:
+        url = (record.get("url") or "").strip()
+        name = record.get("name") or ""
+        artist = record.get("artist") or ""
+        key = url or f"{name}\0{artist}"
+        existing = by_key.get(key)
+        playlists = list(record.get("playlists") or [])
+        if existing is None:
+            by_key[key] = {
+                "name": name,
+                "artist": artist,
+                "url": url,
+                "reason": record.get("reason") or "",
+                "playlists": playlists,
+            }
+            continue
+        for playlist in playlists:
+            if playlist and playlist not in existing["playlists"]:
+                existing["playlists"].append(playlist)
+        reason = record.get("reason") or ""
+        if reason and reason not in (existing.get("reason") or ""):
+            existing["reason"] = (
+                f"{existing['reason']}; {reason}" if existing.get("reason") else reason
+            )
+    return list(by_key.values())
+
+
+def scan_live(cab: Cabinet) -> List[Dict[str, Any]]:
+    client_id = cab.get("spotipy", "client_id")
+    client_secret = cab.get("spotipy", "client_secret")
+    playlists = cab.get("spotipy", "playlists") or []
+    if not client_id or not client_secret:
+        raise RuntimeError("Missing spotipy.client_id / spotipy.client_secret in Cabinet")
+    if not playlists:
+        raise RuntimeError("Missing spotipy.playlists in Cabinet")
+
+    sp = spotipy.Spotify(
+        client_credentials_manager=SpotifyClientCredentials(
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    )
+
+    found: List[Dict[str, Any]] = []
+    for entry in playlists:
+        if not isinstance(entry, str) or "," not in entry:
+            continue
+        playlist_id, playlist_name = entry.split(",", 1)
+        playlist_id = playlist_id.strip()
+        playlist_name = playlist_name.strip()
+        results = sp.playlist_items(playlist_id, market=MARKET)
+        while results:
+            for item in results.get("items") or []:
+                track = item.get("track")
+                if not track:
+                    found.append(
+                        _track_record(playlist_name, None, reason="null track entry")
+                    )
+                    continue
+                if track.get("is_local"):
+                    continue
+                if track.get("is_playable") is False:
+                    found.append(
+                        _track_record(playlist_name, track, reason="is_playable=false")
+                    )
+            if not results.get("next"):
+                break
+            results = sp.next(results)
+
+    return _merge_records(found)
+
+
+def format_text(rows: List[Dict[str, Any]]) -> str:
+    lines: List[str] = []
+    for row in rows:
+        name = row.get("name") or "(unknown)"
+        artist = row.get("artist") or ""
+        url = row.get("url") or ""
+        playlists = ", ".join(row.get("playlists") or [])
+        reason = row.get("reason") or ""
+        label = f"{name} — {artist}" if artist else name
+        bits = [label]
+        if url:
+            bits.append(url)
+        if playlists:
+            bits.append(f"playlists: {playlists}")
+        if reason:
+            bits.append(f"[{reason}]")
+        lines.append(" | ".join(bits))
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Identify Spotify tracks unplayable in the US market"
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Scan playlists via Spotipy instead of reading the daily JSON file",
+    )
+    parser.add_argument(
+        "--json-file",
+        type=str,
+        default=None,
+        help=f"Path to {DEFAULT_FILENAME} (default: $cabinet path.log / {DEFAULT_FILENAME})",
+    )
+    parser.add_argument(
+        "--write",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="Write the identified list to PATH as JSON (also prints summary)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full JSON array to stdout instead of a text summary",
+    )
+    args = parser.parse_args()
+
+    cab = Cabinet()
+    try:
+        if args.live:
+            rows = scan_live(cab)
+        else:
+            path = Path(args.json_file) if args.json_file else default_unplayable_path(cab)
+            try:
+                rows = load_from_file(path)
+            except FileNotFoundError:
+                print(
+                    f"Error: {path} not found. Run daily spotify_analytics first, "
+                    "or pass --live to scan now.",
+                    file=sys.stderr,
+                )
+                return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.write:
+        write_path = Path(args.write).expanduser()
+        write_path.parent.mkdir(parents=True, exist_ok=True)
+        with write_path.open("w", encoding="utf-8") as f:
+            json.dump(rows, f, indent=2, ensure_ascii=False)
+        print(f"Wrote {len(rows)} unplayable track(s) to {write_path}", file=sys.stderr)
+
+    if args.json:
+        json.dump(rows, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+    else:
+        if not rows:
+            print("No unplayable tracks found.")
+        else:
+            print(f"{len(rows)} unplayable track(s):\n")
+            print(format_text(rows))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spotify_analytics/main.py
+++ b/spotify_analytics/main.py
@@ -1039,6 +1039,35 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         self._save_data()
         self._update_statistics()
 
+    def _dedupe_unplayable_tracks(self) -> List[Dict[str, Any]]:
+        """Collapse unplayable records by URL (or name/artist when URL is empty)."""
+        by_key: Dict[str, Dict[str, Any]] = {}
+        for record in self._unplayable_tracks:
+            url = (record.get("url") or "").strip()
+            name = record.get("name") or ""
+            artist = record.get("artist") or ""
+            key = url or f"{name}\0{artist}"
+            existing = by_key.get(key)
+            playlist = record.get("playlist") or ""
+            if existing is None:
+                playlists = [playlist] if playlist else []
+                by_key[key] = {
+                    "name": name,
+                    "artist": artist,
+                    "url": url,
+                    "reason": record.get("reason") or "",
+                    "playlists": playlists,
+                }
+                continue
+            if playlist and playlist not in existing["playlists"]:
+                existing["playlists"].append(playlist)
+            reason = record.get("reason") or ""
+            if reason and reason not in (existing.get("reason") or ""):
+                existing["reason"] = (
+                    f"{existing['reason']}; {reason}" if existing.get("reason") else reason
+                )
+        return list(by_key.values())
+
     def _save_data(self):
         """Save processed track data to JSON file."""
         # Use existing path if already set by prepare_git_repo
@@ -1057,6 +1086,14 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
             json.dump(track_data, f, indent=2, ensure_ascii=False)
 
         self.cab.log(f"SPOTIFY - Saved track data to {output_file}")
+
+        unplayable_file = output_path / "spotify unplayable.json"
+        unplayable_data = self._dedupe_unplayable_tracks()
+        with open(unplayable_file, "w", encoding="utf-8") as f:
+            json.dump(unplayable_data, f, indent=2, ensure_ascii=False)
+        self.cab.log(
+            f"SPOTIFY - Saved {len(unplayable_data)} unplayable track(s) to {unplayable_file}"
+        )
 
     def _load_genre_cache_from_json(self, json_file: Optional[Path] = None) -> None:
         """Load genre cache from existing JSON file.

--- a/spotify_analytics/main.py
+++ b/spotify_analytics/main.py
@@ -1039,28 +1039,39 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         self._save_data()
         self._update_statistics()
 
+    def _primary_playlist_name(self) -> str:
+        """First configured playlist label (Tyler Radio in the usual setup)."""
+        playlists = self._get_playlists()
+        if playlists and isinstance(playlists[0], str) and "," in playlists[0]:
+            return playlists[0].split(",", 1)[1].strip() or "Tyler Radio"
+        return "Tyler Radio"
+
     def _dedupe_unplayable_tracks(self) -> List[Dict[str, Any]]:
-        """Collapse unplayable records by URL (or name/artist when URL is empty)."""
+        """Collapse unplayable records for the primary playlist only (Tyler Radio).
+
+        Other playlists are still logged as warnings during analysis, but
+        ``spotify unplayable.json`` is scoped to the main library playlist.
+        """
+        primary = self._primary_playlist_name()
         by_key: Dict[str, Dict[str, Any]] = {}
         for record in self._unplayable_tracks:
+            playlist = record.get("playlist") or ""
+            if playlist != primary:
+                continue
             url = (record.get("url") or "").strip()
             name = record.get("name") or ""
             artist = record.get("artist") or ""
             key = url or f"{name}\0{artist}"
             existing = by_key.get(key)
-            playlist = record.get("playlist") or ""
             if existing is None:
-                playlists = [playlist] if playlist else []
                 by_key[key] = {
                     "name": name,
                     "artist": artist,
                     "url": url,
                     "reason": record.get("reason") or "",
-                    "playlists": playlists,
+                    "playlists": [playlist] if playlist else [],
                 }
                 continue
-            if playlist and playlist not in existing["playlists"]:
-                existing["playlists"].append(playlist)
             reason = record.get("reason") or ""
             if reason and reason not in (existing.get("reason") or ""):
                 existing["reason"] = (

--- a/spotify_analytics/replace_unplayable.py
+++ b/spotify_analytics/replace_unplayable.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""
+Replace unplayable Spotify tracks with local YouTube downloads (TJW-328 phase 2).
+
+For each entry in `spotify unplayable.json`:
+  1. Fetch Spotify track duration
+  2. Search YouTube and pick the candidate whose length is closest to that duration
+     (rejects long music-video / mix uploads outside the tolerance)
+  3. Download via the music-stack `mp3` helper into ~/syncthing/music
+  4. Optionally remove the unplayable Spotify URI from playlists (--update-spotify)
+
+Spotify's Web API cannot add local files to playlists; removal clears greyed-out
+entries once a Navidrome/local copy exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import spotipy
+from cabinet import Cabinet
+from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOAuth
+
+MARKET = "US"
+DEFAULT_UNPLAYABLE = "spotify unplayable.json"
+DEFAULT_SEARCH_RESULTS = 8
+DEFAULT_TOLERANCE_SEC = 15.0
+
+
+def default_unplayable_path(cab: Cabinet) -> Path:
+    log_path = cab.get("path", "log") or str(Path.home())
+    return Path(log_path) / DEFAULT_UNPLAYABLE
+
+
+def resolve_mp3_exec(mp3_cmd: str) -> Optional[List[str]]:
+    expanded = Path(mp3_cmd).expanduser()
+    if expanded.is_file():
+        return [str(expanded)]
+    found = shutil.which(mp3_cmd)
+    if found:
+        return [found]
+    fallback = (
+        Path.home() / "git" / "docker" / "music-stack" / "scripts" / "mp3"
+    )
+    if fallback.is_file():
+        return [str(fallback)]
+    print(
+        f"ERROR: `{mp3_cmd}` not found (tried PATH and {fallback}).",
+        file=sys.stderr,
+    )
+    return None
+
+
+def resolve_ytdlp() -> List[str]:
+    if shutil.which("yt-dlp"):
+        return ["yt-dlp"]
+    local = Path.home() / ".local" / "bin" / "yt-dlp"
+    if local.is_file():
+        return [str(local)]
+    try:
+        subprocess.run(
+            [sys.executable, "-m", "yt_dlp", "--version"],
+            capture_output=True,
+            check=True,
+        )
+        return [sys.executable, "-m", "yt_dlp"]
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        raise RuntimeError("yt-dlp not found") from exc
+
+
+def extract_track_id(url: str) -> Optional[str]:
+    if not url:
+        return None
+    match = re.search(r"track/([a-zA-Z0-9]+)", url)
+    if match:
+        return match.group(1)
+    if re.fullmatch(r"[a-zA-Z0-9]{22}", url.strip()):
+        return url.strip()
+    return None
+
+
+def load_unplayable(path: Path) -> List[Dict[str, Any]]:
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError(f"Expected JSON array in {path}")
+    return [row for row in data if isinstance(row, dict)]
+
+
+def playlist_name_to_id(cab: Cabinet) -> Dict[str, str]:
+    mapping: Dict[str, str] = {}
+    for entry in cab.get("spotipy", "playlists") or []:
+        if not isinstance(entry, str) or "," not in entry:
+            continue
+        playlist_id, name = entry.split(",", 1)
+        mapping[name.strip()] = playlist_id.strip()
+    return mapping
+
+
+def spotify_client_credentials(cab: Cabinet) -> spotipy.Spotify:
+    client_id = cab.get("spotipy", "client_id")
+    client_secret = cab.get("spotipy", "client_secret")
+    if not client_id or not client_secret:
+        raise RuntimeError("Missing spotipy.client_id / client_secret in Cabinet")
+    return spotipy.Spotify(
+        client_credentials_manager=SpotifyClientCredentials(
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    )
+
+
+def spotify_oauth_client(cab: Cabinet) -> spotipy.Spotify:
+    """OAuth client for playlist modifications (reuse analytics cache path)."""
+    client_id = cab.get("spotipy", "client_id")
+    client_secret = cab.get("spotipy", "client_secret")
+    username = cab.get("spotipy", "username") or "user"
+    if not client_id or not client_secret:
+        raise RuntimeError("Missing spotipy.client_id / client_secret in Cabinet")
+
+    cache_path = str(
+        Path(__file__).resolve().parent / f".cache-{username}"
+    )
+    auth = SpotifyOAuth(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri="http://127.0.0.1:8888/callback",
+        scope="playlist-modify-public playlist-modify-private",
+        cache_path=cache_path,
+        open_browser=False,
+    )
+    token = auth.get_cached_token()
+    if not token:
+        raise RuntimeError(
+            "No Spotify OAuth cache. Run: python3 main.py --reauthorize"
+        )
+    return spotipy.Spotify(auth=token["access_token"])
+
+
+def fetch_duration_ms(sp: spotipy.Spotify, track_id: str) -> Optional[int]:
+    track = sp.track(track_id, market=MARKET)
+    duration = track.get("duration_ms")
+    if isinstance(duration, int) and duration > 0:
+        return duration
+    return None
+
+
+def youtube_search(
+    ytdlp: List[str],
+    query: str,
+    results: int,
+) -> List[Dict[str, Any]]:
+    """Return flat search hits with id/title/duration (seconds)."""
+    search = f"ytsearch{results}:{query}"
+    proc = subprocess.run(
+        [
+            *ytdlp,
+            "--flat-playlist",
+            "--dump-json",
+            "--no-download",
+            search,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0 and not proc.stdout.strip():
+        err = (proc.stderr or "").strip().splitlines()
+        detail = err[-1] if err else f"exit {proc.returncode}"
+        raise RuntimeError(f"yt-dlp search failed: {detail}")
+
+    candidates: List[Dict[str, Any]] = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        video_id = row.get("id")
+        duration = row.get("duration")
+        if not video_id or duration is None:
+            continue
+        try:
+            duration_f = float(duration)
+        except (TypeError, ValueError):
+            continue
+        if duration_f <= 0:
+            continue
+        candidates.append(
+            {
+                "id": str(video_id),
+                "title": row.get("title") or "",
+                "duration": duration_f,
+                "url": f"https://www.youtube.com/watch?v={video_id}",
+            }
+        )
+    return candidates
+
+
+def pick_closest_duration(
+    candidates: List[Dict[str, Any]],
+    target_sec: float,
+    tolerance_sec: float,
+) -> Optional[Tuple[Dict[str, Any], float]]:
+    best: Optional[Dict[str, Any]] = None
+    best_diff = float("inf")
+    for cand in candidates:
+        diff = abs(float(cand["duration"]) - target_sec)
+        if diff < best_diff:
+            best = cand
+            best_diff = diff
+    if best is None or best_diff > tolerance_sec:
+        return None
+    return best, best_diff
+
+
+def download_with_mp3(
+    mp3_exec: List[str],
+    youtube_url: str,
+    artist: str,
+    title: str,
+    dry_run: bool,
+) -> int:
+    env = os.environ.copy()
+    env["MP3_STEM_TITLE"] = title
+    env["MP3_STEM_ARTIST"] = artist
+    cmd = [*mp3_exec]
+    if dry_run:
+        cmd.append("--dry-run")
+    cmd.append(youtube_url)
+    if dry_run:
+        print(
+            f"  DRY-RUN: MP3_STEM_TITLE={title!r} MP3_STEM_ARTIST={artist!r} "
+            + subprocess.list2cmdline(cmd),
+            file=sys.stderr,
+        )
+        return 0
+    print(f"  mp3 {youtube_url}", file=sys.stderr)
+    return subprocess.run(cmd, env=env).returncode
+
+
+def remove_from_playlists(
+    oauth: Optional[spotipy.Spotify],
+    track_id: str,
+    playlist_names: List[str],
+    name_to_id: Dict[str, str],
+    dry_run: bool,
+) -> List[str]:
+    removed: List[str] = []
+    for name in playlist_names:
+        playlist_id = name_to_id.get(name)
+        if not playlist_id:
+            print(f"  WARN: unknown playlist {name!r}, skip remove", file=sys.stderr)
+            continue
+        if dry_run:
+            print(
+                f"  DRY-RUN: would remove {track_id} from {name} ({playlist_id})",
+                file=sys.stderr,
+            )
+            removed.append(name)
+            continue
+        if oauth is None:
+            print(f"  WARN: no OAuth; cannot remove from {name}", file=sys.stderr)
+            continue
+        try:
+            oauth.playlist_remove_all_occurrences_of_items(playlist_id, [track_id])
+            print(f"  Removed from {name}", file=sys.stderr)
+            removed.append(name)
+        except Exception as exc:  # noqa: BLE001
+            print(f"  WARN: failed to remove from {name}: {exc}", file=sys.stderr)
+    return removed
+
+
+def process_row(
+    row: Dict[str, Any],
+    *,
+    sp: spotipy.Spotify,
+    ytdlp: List[str],
+    mp3_exec: List[str],
+    search_results: int,
+    tolerance_sec: float,
+    dry_run: bool,
+    update_spotify: bool,
+    oauth: Optional[spotipy.Spotify],
+    name_to_id: Dict[str, str],
+) -> str:
+    """Return status: ok | skip | fail."""
+    name = (row.get("name") or "").strip()
+    artist = (row.get("artist") or "").strip()
+    url = (row.get("url") or "").strip()
+    playlists = list(row.get("playlists") or [])
+
+    if not name or name == "(unknown)":
+        print("  SKIP: missing/unknown title", file=sys.stderr)
+        return "skip"
+    if not artist:
+        print("  SKIP: missing artist", file=sys.stderr)
+        return "skip"
+
+    track_id = extract_track_id(url)
+    if not track_id:
+        print(f"  SKIP: cannot parse Spotify track id from {url!r}", file=sys.stderr)
+        return "skip"
+
+    duration_ms = fetch_duration_ms(sp, track_id)
+    if duration_ms is None:
+        print("  SKIP: Spotify duration unavailable", file=sys.stderr)
+        return "skip"
+    target_sec = duration_ms / 1000.0
+
+    query = f"{artist} {name} audio"
+    print(
+        f"  Spotify duration={target_sec:.1f}s; searching YouTube: {query!r}",
+        file=sys.stderr,
+    )
+    candidates = youtube_search(ytdlp, query, search_results)
+    picked = pick_closest_duration(candidates, target_sec, tolerance_sec)
+    if not picked:
+        preview = ", ".join(
+            f"{c['duration']:.0f}s:{c['title'][:40]}" for c in candidates[:5]
+        ) or "(none)"
+        print(
+            f"  FAIL: no YouTube hit within ±{tolerance_sec:g}s "
+            f"(target {target_sec:.1f}s); candidates: {preview}",
+            file=sys.stderr,
+        )
+        return "fail"
+
+    cand, diff = picked
+    print(
+        f"  Picked {cand['id']} ({cand['duration']:.1f}s, Δ{diff:.1f}s) "
+        f"{cand['title']!r}",
+        file=sys.stderr,
+    )
+
+    rc = download_with_mp3(mp3_exec, cand["url"], artist, name, dry_run=dry_run)
+    if rc != 0:
+        print(f"  FAIL: mp3 exited {rc}", file=sys.stderr)
+        return "fail"
+
+    if update_spotify and playlists:
+        if not dry_run and oauth is None:
+            print("  WARN: OAuth unavailable; skipped Spotify remove", file=sys.stderr)
+        else:
+            remove_from_playlists(
+                oauth,
+                track_id,
+                playlists,
+                name_to_id,
+                dry_run=dry_run,
+            )
+
+    return "ok"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download YouTube audio for unplayable Spotify tracks, "
+            "preferring videos closest in length to the Spotify duration"
+        )
+    )
+    parser.add_argument(
+        "--json-file",
+        type=str,
+        default=None,
+        help=f"Path to {DEFAULT_UNPLAYABLE} (default: Cabinet path.log)",
+    )
+    parser.add_argument(
+        "--mp3",
+        default="mp3",
+        help="mp3 helper on PATH or path to docker/music-stack/scripts/mp3",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Process at most N tracks (0 = all)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Search and select only; do not download or modify Spotify",
+    )
+    parser.add_argument(
+        "--update-spotify",
+        action="store_true",
+        help=(
+            "After a successful download, remove the unplayable track from "
+            "its Spotify playlists (API cannot add local files)"
+        ),
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=float,
+        default=DEFAULT_TOLERANCE_SEC,
+        metavar="SEC",
+        help=f"Max |YouTube−Spotify| duration delta in seconds (default {DEFAULT_TOLERANCE_SEC:g})",
+    )
+    parser.add_argument(
+        "--search-results",
+        type=int,
+        default=DEFAULT_SEARCH_RESULTS,
+        metavar="N",
+        help=f"ytsearchN depth (default {DEFAULT_SEARCH_RESULTS})",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Required when processing more than 10 tracks without --dry-run",
+    )
+    args = parser.parse_args()
+
+    cab = Cabinet()
+    path = Path(args.json_file) if args.json_file else default_unplayable_path(cab)
+    if not path.is_file():
+        print(
+            f"ERROR: {path} not found. Run identify_unplayable.py --live --write … first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    mp3_exec = resolve_mp3_exec(args.mp3)
+    if mp3_exec is None:
+        return 1
+
+    try:
+        rows = load_unplayable(path)
+        ytdlp = resolve_ytdlp()
+        sp = spotify_client_credentials(cab)
+    except Exception as exc:  # noqa: BLE001
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    if args.limit and args.limit > 0:
+        rows = rows[: args.limit]
+
+    if len(rows) > 10 and not args.yes and not args.dry_run:
+        print(
+            f"Refusing to process {len(rows)} tracks without --yes "
+            "(use --dry-run, --limit N, or --yes).",
+            file=sys.stderr,
+        )
+        return 1
+
+    oauth: Optional[spotipy.Spotify] = None
+    name_to_id = playlist_name_to_id(cab)
+    if args.update_spotify and not args.dry_run:
+        try:
+            oauth = spotify_oauth_client(cab)
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR: Spotify OAuth required for --update-spotify: {exc}", file=sys.stderr)
+            return 1
+
+    print(f"Processing {len(rows)} unplayable track(s) from {path}", file=sys.stderr)
+    counts = {"ok": 0, "skip": 0, "fail": 0}
+    for i, row in enumerate(rows, 1):
+        label = f"{row.get('name') or '?'} — {row.get('artist') or '?'}"
+        print(f"\n[{i}/{len(rows)}] {label}", file=sys.stderr)
+        try:
+            status = process_row(
+                row,
+                sp=sp,
+                ytdlp=ytdlp,
+                mp3_exec=mp3_exec,
+                search_results=max(1, args.search_results),
+                tolerance_sec=args.tolerance,
+                dry_run=args.dry_run,
+                update_spotify=args.update_spotify,
+                oauth=oauth,
+                name_to_id=name_to_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"  FAIL: {exc}", file=sys.stderr)
+            status = "fail"
+        counts[status] = counts.get(status, 0) + 1
+
+    print(
+        f"\nDone. ok={counts['ok']} skip={counts['skip']} fail={counts['fail']}",
+        file=sys.stderr,
+    )
+    return 0 if counts["fail"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/spotify_analytics/replace_unplayable.py
+++ b/spotify_analytics/replace_unplayable.py
@@ -31,8 +31,26 @@ from spotipy.oauth2 import SpotifyClientCredentials, SpotifyOAuth
 
 MARKET = "US"
 DEFAULT_UNPLAYABLE = "spotify unplayable.json"
-DEFAULT_SEARCH_RESULTS = 8
+DEFAULT_SEARCH_RESULTS = 12
 DEFAULT_TOLERANCE_SEC = 15.0
+
+# Titles/artists that cannot drive a reliable YouTube search.
+_PLACEHOLDER_RE = re.compile(
+    r"^\s*[\(\[\{\s]*(?:unknown|n/?a|none|null|untitled|track|tbd)[\)\]\}\s]*\.?\s*$",
+    re.IGNORECASE,
+)
+
+# Soft penalties added to duration delta when ranking YouTube hits (seconds-equivalent).
+_TITLE_PENALTIES: List[Tuple[re.Pattern[str], float]] = [
+    (re.compile(r"\bclean\b", re.I), 40.0),
+    (re.compile(r"\bcensored\b", re.I), 40.0),
+    (re.compile(r"\bradio\s*edit\b", re.I), 25.0),
+    (re.compile(r"\blive\b", re.I), 35.0),
+    (re.compile(r"\bcover\b", re.I), 35.0),
+    (re.compile(r"\bkaraoke\b", re.I), 80.0),
+    (re.compile(r"\binstrumental\b", re.I), 35.0),
+    (re.compile(r"\blyric(?:s)?\b", re.I), 8.0),
+]
 
 
 def default_unplayable_path(cab: Cabinet) -> Path:
@@ -145,12 +163,109 @@ def spotify_oauth_client(cab: Cabinet) -> spotipy.Spotify:
     return spotipy.Spotify(auth=token["access_token"])
 
 
-def fetch_duration_ms(sp: spotipy.Spotify, track_id: str) -> Optional[int]:
+def is_placeholder(value: str) -> bool:
+    """True for blank / (unknown) / N/A style metadata that should be skipped."""
+    text = (value or "").strip()
+    if not text:
+        return True
+    return bool(_PLACEHOLDER_RE.match(text))
+
+
+def fold_alnum(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", (value or "").lower())
+
+
+def artist_in_text(artist: str, *parts: str) -> bool:
+    """Require the Spotify artist (folded) to appear in YouTube title and/or channel."""
+    needle = fold_alnum(artist)
+    if len(needle) < 2:
+        return False
+    hay = fold_alnum(" ".join(p for p in parts if p))
+    return needle in hay
+
+
+def title_token_bonus(track_name: str, video_title: str) -> float:
+    """Reward overlap of significant title words (reduces score)."""
+    stop = {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "of",
+        "feat",
+        "ft",
+        "featuring",
+        "with",
+        "official",
+        "audio",
+        "video",
+        "music",
+        "lyrics",
+        "hd",
+        "hq",
+    }
+    track_tokens = [
+        t
+        for t in re.findall(r"[a-z0-9]+", track_name.lower())
+        if len(t) > 1 and t not in stop
+    ]
+    if not track_tokens:
+        return 0.0
+    hay = set(re.findall(r"[a-z0-9]+", video_title.lower()))
+    matched = sum(1 for t in track_tokens if t in hay)
+    # Up to ~12s equivalent bonus for full title overlap
+    return -12.0 * (matched / len(track_tokens))
+
+
+def title_penalties(video_title: str, *, want_explicit: bool) -> float:
+    penalty = 0.0
+    for pattern, amount in _TITLE_PENALTIES:
+        if pattern.search(video_title):
+            penalty += amount
+    if want_explicit and re.search(r"\bclean\b|\bcensored\b", video_title, re.I):
+        penalty += 60.0
+    if want_explicit and re.search(r"\bexplicit\b|\buncensored\b", video_title, re.I):
+        penalty -= 8.0
+    return penalty
+
+
+def build_search_queries(artist: str, name: str) -> List[str]:
+    """Ordered YouTube queries; quoted artist first to avoid same-title wrong-artist hits."""
+    queries: List[str] = []
+    seen: set[str] = set()
+
+    def add(q: str) -> None:
+        q = " ".join(q.split())
+        if q and q not in seen:
+            seen.add(q)
+            queries.append(q)
+
+    add(f'"{artist}" {name}')
+    add(f"{artist} {name}")
+    # Drop trailing parenthetical / " - Original" style suffixes for a looser pass
+    loose = re.sub(r"\s*[\(\[].*?[\)\]]\s*", " ", name)
+    loose = re.sub(r"\s+-\s+(original|radio\s*edit|remaster(?:ed)?)\s*$", "", loose, flags=re.I)
+    loose = " ".join(loose.split())
+    if loose and loose.lower() != name.lower():
+        add(f'"{artist}" {loose}')
+        add(f"{artist} {loose}")
+    return queries
+
+
+def fetch_track_meta(sp: spotipy.Spotify, track_id: str) -> Dict[str, Any]:
     track = sp.track(track_id, market=MARKET)
+    artists = track.get("artists") or []
+    artist = ""
+    if artists:
+        artist = (artists[0].get("name") or "").strip()
     duration = track.get("duration_ms")
-    if isinstance(duration, int) and duration > 0:
-        return duration
-    return None
+    return {
+        "name": (track.get("name") or "").strip(),
+        "artist": artist,
+        "duration_ms": duration if isinstance(duration, int) and duration > 0 else None,
+        "explicit": bool(track.get("explicit")),
+    }
 
 
 def youtube_search(
@@ -196,10 +311,12 @@ def youtube_search(
             continue
         if duration_f <= 0:
             continue
+        channel = row.get("channel") or row.get("uploader") or ""
         candidates.append(
             {
                 "id": str(video_id),
                 "title": row.get("title") or "",
+                "channel": channel,
                 "duration": duration_f,
                 "url": f"https://www.youtube.com/watch?v={video_id}",
             }
@@ -207,21 +324,43 @@ def youtube_search(
     return candidates
 
 
-def pick_closest_duration(
+def pick_best_candidate(
     candidates: List[Dict[str, Any]],
+    *,
+    artist: str,
+    track_name: str,
     target_sec: float,
     tolerance_sec: float,
-) -> Optional[Tuple[Dict[str, Any], float]]:
+    want_explicit: bool,
+) -> Optional[Tuple[Dict[str, Any], float, float]]:
+    """
+    Pick best YouTube hit: must include artist + duration within tolerance.
+    Rank by duration delta + clean/live/cover penalties − title overlap bonus.
+    Returns (candidate, duration_diff, score).
+    """
     best: Optional[Dict[str, Any]] = None
+    best_score = float("inf")
     best_diff = float("inf")
+
     for cand in candidates:
+        if not artist_in_text(artist, cand.get("title") or "", cand.get("channel") or ""):
+            continue
         diff = abs(float(cand["duration"]) - target_sec)
-        if diff < best_diff:
+        if diff > tolerance_sec:
+            continue
+        score = (
+            diff
+            + title_penalties(cand.get("title") or "", want_explicit=want_explicit)
+            + title_token_bonus(track_name, cand.get("title") or "")
+        )
+        if score < best_score:
             best = cand
+            best_score = score
             best_diff = diff
-    if best is None or best_diff > tolerance_sec:
+
+    if best is None:
         return None
-    return best, best_diff
+    return best, best_diff, best_score
 
 
 def download_with_mp3(
@@ -300,46 +439,81 @@ def process_row(
     url = (row.get("url") or "").strip()
     playlists = list(row.get("playlists") or [])
 
-    if not name or name == "(unknown)":
-        print("  SKIP: missing/unknown title", file=sys.stderr)
-        return "skip"
-    if not artist:
-        print("  SKIP: missing artist", file=sys.stderr)
-        return "skip"
-
     track_id = extract_track_id(url)
     if not track_id:
         print(f"  SKIP: cannot parse Spotify track id from {url!r}", file=sys.stderr)
         return "skip"
 
-    duration_ms = fetch_duration_ms(sp, track_id)
+    meta = fetch_track_meta(sp, track_id)
+    # Prefer live Spotify metadata when the unplayable export has placeholders.
+    if is_placeholder(name) and not is_placeholder(meta["name"]):
+        name = meta["name"]
+    if is_placeholder(artist) and not is_placeholder(meta["artist"]):
+        artist = meta["artist"]
+
+    if is_placeholder(name):
+        print("  SKIP: missing/unknown title", file=sys.stderr)
+        return "skip"
+    if is_placeholder(artist):
+        print("  SKIP: missing/unknown artist", file=sys.stderr)
+        return "skip"
+
+    duration_ms = meta["duration_ms"]
     if duration_ms is None:
         print("  SKIP: Spotify duration unavailable", file=sys.stderr)
         return "skip"
     target_sec = duration_ms / 1000.0
+    want_explicit = bool(meta["explicit"])
 
-    query = f"{artist} {name} audio"
-    print(
-        f"  Spotify duration={target_sec:.1f}s; searching YouTube: {query!r}",
-        file=sys.stderr,
-    )
-    candidates = youtube_search(ytdlp, query, search_results)
-    picked = pick_closest_duration(candidates, target_sec, tolerance_sec)
+    queries = build_search_queries(artist, name)
+    picked: Optional[Tuple[Dict[str, Any], float, float]] = None
+    all_candidates: List[Dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for query in queries:
+        print(
+            f"  Spotify duration={target_sec:.1f}s"
+            f"{' explicit' if want_explicit else ''}; "
+            f"searching YouTube: {query!r}",
+            file=sys.stderr,
+        )
+        batch = youtube_search(ytdlp, query, search_results)
+        for cand in batch:
+            if cand["id"] not in seen_ids:
+                seen_ids.add(cand["id"])
+                all_candidates.append(cand)
+        picked = pick_best_candidate(
+            all_candidates,
+            artist=artist,
+            track_name=name,
+            target_sec=target_sec,
+            tolerance_sec=tolerance_sec,
+            want_explicit=want_explicit,
+        )
+        if picked:
+            break
+
     if not picked:
+        artist_hits = [
+            c
+            for c in all_candidates
+            if artist_in_text(artist, c.get("title") or "", c.get("channel") or "")
+        ]
+        preview_src = artist_hits or all_candidates
         preview = ", ".join(
-            f"{c['duration']:.0f}s:{c['title'][:40]}" for c in candidates[:5]
+            f"{c['duration']:.0f}s:{c['title'][:40]}" for c in preview_src[:5]
         ) or "(none)"
         print(
-            f"  FAIL: no YouTube hit within ±{tolerance_sec:g}s "
-            f"(target {target_sec:.1f}s); candidates: {preview}",
+            f"  FAIL: no artist+duration match within ±{tolerance_sec:g}s "
+            f"(target {target_sec:.1f}s, artist={artist!r}); candidates: {preview}",
             file=sys.stderr,
         )
         return "fail"
 
-    cand, diff = picked
+    cand, diff, score = picked
     print(
-        f"  Picked {cand['id']} ({cand['duration']:.1f}s, Δ{diff:.1f}s) "
-        f"{cand['title']!r}",
+        f"  Picked {cand['id']} ({cand['duration']:.1f}s, Δ{diff:.1f}s, "
+        f"score={score:.1f}) {cand['title']!r}",
         file=sys.stderr,
     )
 

--- a/spotify_analytics/replace_unplayable.py
+++ b/spotify_analytics/replace_unplayable.py
@@ -123,6 +123,31 @@ def playlist_name_to_id(cab: Cabinet) -> Dict[str, str]:
     return mapping
 
 
+def primary_playlist_name(cab: Cabinet) -> str:
+    """First configured spotipy playlist label (Tyler Radio in the usual setup)."""
+    for entry in cab.get("spotipy", "playlists") or []:
+        if isinstance(entry, str) and "," in entry:
+            return entry.split(",", 1)[1].strip() or "Tyler Radio"
+    return "Tyler Radio"
+
+
+def filter_by_playlist(
+    rows: List[Dict[str, Any]],
+    playlist: Optional[str],
+) -> List[Dict[str, Any]]:
+    """Keep rows that appear on ``playlist``. None / empty = no filter."""
+    if not playlist:
+        return rows
+    wanted = playlist.strip().lower()
+    return [
+        row
+        for row in rows
+        if any(
+            (p or "").strip().lower() == wanted for p in (row.get("playlists") or [])
+        )
+    ]
+
+
 def spotify_client_credentials(cab: Cabinet) -> spotipy.Spotify:
     client_id = cab.get("spotipy", "client_id")
     client_secret = cab.get("spotipy", "client_secret")
@@ -551,6 +576,22 @@ def main() -> int:
         help=f"Path to {DEFAULT_UNPLAYABLE} (default: Cabinet path.log)",
     )
     parser.add_argument(
+        "--playlist",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help=(
+            "Only process tracks that appear on this playlist "
+            "(default: first Cabinet spotipy playlist, usually Tyler Radio). "
+            "Pass empty string --playlist '' for all playlists."
+        ),
+    )
+    parser.add_argument(
+        "--all-playlists",
+        action="store_true",
+        help="Process every unplayable track (including Removed-only). Overrides --playlist.",
+    )
+    parser.add_argument(
         "--mp3",
         default="mp3",
         help="mp3 helper on PATH or path to docker/music-stack/scripts/mp3",
@@ -617,6 +658,22 @@ def main() -> int:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 1
 
+    if args.all_playlists:
+        playlist_filter: Optional[str] = None
+    elif args.playlist is not None:
+        playlist_filter = args.playlist.strip() or None
+    else:
+        playlist_filter = primary_playlist_name(cab)
+
+    before = len(rows)
+    rows = filter_by_playlist(rows, playlist_filter)
+    if playlist_filter:
+        print(
+            f"Playlist filter: {playlist_filter!r} "
+            f"({len(rows)}/{before} unplayable track(s))",
+            file=sys.stderr,
+        )
+
     if args.limit and args.limit > 0:
         rows = rows[: args.limit]
 
@@ -637,7 +694,11 @@ def main() -> int:
             print(f"ERROR: Spotify OAuth required for --update-spotify: {exc}", file=sys.stderr)
             return 1
 
-    print(f"Processing {len(rows)} unplayable track(s) from {path}", file=sys.stderr)
+    scope = playlist_filter or "all playlists"
+    print(
+        f"Processing {len(rows)} unplayable track(s) from {path} ({scope})",
+        file=sys.stderr,
+    )
     counts = {"ok": 0, "skip": 0, "fail": 0}
     for i, row in enumerate(rows, 1):
         label = f"{row.get('name') or '?'} — {row.get('artist') or '?'}"


### PR DESCRIPTION
## Summary
- **Phase 1:** Daily run writes `spotify unplayable.json`; `identify_unplayable.py` lists or live-scans unplayable tracks
- **Phase 2:** `replace_unplayable.py` searches YouTube, picks the upload closest in length to the Spotify duration (±15s), downloads via music-stack `mp3` into `~/syncthing/music`
- Optional `--update-spotify` removes greyed-out URIs from playlists (API cannot add local files)

## Test plan
- [x] `python3 identify_unplayable.py --live` → ~119 unique tracks
- [x] `python3 replace_unplayable.py --dry-run --limit 3` picks duration-matched YouTube IDs
- [x] `python3 replace_unplayable.py --limit 1` downloads Jupiter Unison (~204.7s vs Spotify 202.6s)
- [ ] Spot-check a few more with `--limit 5` before `--yes` on the full list
- [ ] Optional: `--update-spotify` on one track after confirming the local file in Navidrome

Companion docker change (mp3 accepts direct YouTube URLs): https://git.tyler.cloud/voice2749/docker/pulls/new/feat/TJW-328-mp3-youtube-url