### PR TITLE
TJW-333: Update milestone and finance_parser notes paths

### DIFF
--- a/finance_parser/main.py
+++ b/finance_parser/main.py
@@ -506,7 +506,7 @@ def main() -> None:
 
         # Set the path for the category JSON file
         categories_file_path = (
-            Path.home() / "syncthing/md/docs/selfhosted/transaction_categories.json"
+            Path.home() / "syncthing/notes/docs/selfhosted/transaction_categories.json"
         )
 
         # Find files in Downloads or fall back to file browser

--- a/milestone/main.py
+++ b/milestone/main.py
@@ -29,7 +29,7 @@ def milestones_path() -> Path:
     notes = os.environ.get("notes")
     if notes:
         return Path(notes) / "milestones.md"
-    return Path.home() / "syncthing/md/notes/milestones.md"
+    return Path.home() / "syncthing/notes/milestones.md"
 
 
 def year_bounds(lines: list[str], year: int) -> tuple[int, int] | None:


### PR DESCRIPTION
## Summary
- Point milestone fallback and finance_parser category JSON at `~/syncthing/notes` after the md→notes rename/flatten.

## Test plan
- [ ] `milestone` can resolve `milestones.md` via `$notes` or the new fallback path
- [ ] finance_parser still finds `docs/selfhosted/transaction_categories.json`


Made with [Cursor](https://cursor.com)