### PR TITLE
TJW-316: Personal SRE scorecard in dailystatus email

### DIFF
--- a/dailystatus/README.md
+++ b/dailystatus/README.md
@@ -5,11 +5,11 @@
 
 ## Email layout
 
-1. Greeting + casual tomorrow weather (`68 and partly cloudy tomorrow`) from Cabinet `weather.data`
-2. **Personal SRE Scorecard** table
+1. Greeting + casual tomorrow weather (`<b>Weather</b> is 68° and partly cloudy tomorrow`) from Cabinet `weather.data`
+2. **Personal Metrics** table
 3. Other sections (foodlog, Spotify details, warnings table, …)
 
-## Personal SRE scorecard
+## Personal Metrics
 
 Fields (missing data → `unknown / not configured`, never crash the email):
 
@@ -19,8 +19,8 @@ Fields (missing data → `unknown / not configured`, never crash the email):
 | Disk free space | Cabinet `quality.<host>.free_gb` from `quality/service_check.py` |
 | Pi-hole | Local Docker `pihole` container + `pihole status` when available |
 | Rainbow | Ping host from `path.rainbow-borg`; `quality.rainbow.updated_at` as “last health check”; uptime when running on rainbow |
-| Spotify analytics | `Checked <age>; <n> songs.` from `spotipy.last_success` / `total_tracks` (stale if &gt; 24h) |
-| Warnings / errors (24h) | Prefer Cabinet **Loki** (`log_query_issues_loki`) so rainbow sees cloud logs after Mongo log removal; fall back to local files |
+| Spotify analytics | `Checked <age>; <n> songs; avg year <y>.` from `spotipy` |
+| Warnings / errors (24h) | Prefer Cabinet **Loki**; when issues exist, `(source: loki)` links to Grafana Explore |
 
 The detailed warnings/errors section below the scorecard uses the same query, rendered as a compact level/message table.
 

--- a/dailystatus/README.md
+++ b/dailystatus/README.md
@@ -19,7 +19,7 @@ Fields (missing data → `unknown / not configured`, never crash the email):
 | Disk free space | Cabinet `quality.<host>.free_gb` from `quality/service_check.py` |
 | Pi-hole | Local Docker `pihole` container + `pihole status` when available |
 | Rainbow | Ping host from `path.rainbow-borg`; `quality.rainbow.updated_at` as “last health check”; uptime when running on rainbow |
-| Spotify analytics | `Checked <age>; <n> songs; avg year <y>.` from `spotipy` |
+| Spotify analytics | `Checked <age>; <n> songs; avg year <full decimal>.` from `spotipy` |
 | Warnings / errors (24h) | Prefer Cabinet **Loki**; when issues exist, `(source: loki)` links to Grafana Explore |
 
 The detailed warnings/errors section below the scorecard uses the same query, rendered as a compact level/message table.

--- a/dailystatus/README.md
+++ b/dailystatus/README.md
@@ -1,10 +1,33 @@
 # dailystatus
 - Feel free to clone, but this is very custom to my setup and backup process
-- Backs up logs, crontab, etc. 
+- Backs up logs, crontab, etc.
 - Sends me an email each day with my home automation status, the weather forecast, Spotify information, and anything else I find useful
 
+## Personal SRE scorecard
+
+Every email starts with a **Personal SRE Scorecard** HTML table. Fields (missing data → `unknown / not configured`, never crash the email):
+
+| Check | Source |
+|-------|--------|
+| Borg backups | `borg list` on `keys.borg.repo` (+ recent `~/.cabinet/log/borg-errors`) |
+| Cloud / Rainbow drift | Cabinet `quality.<host>.updated_at` / `free_gb` from `quality/service_check.py` |
+| SSL expiry | TLS `notAfter` for common `*.tyler.cloud` hosts |
+| Disk free space | Same `quality` data (folded into the scorecard) |
+| Pi-hole | Local Docker `pihole` container + `pihole status` when available |
+| Rainbow | Ping host from `path.rainbow-borg`, quality row, local uptime if hostname is `rainbow` |
+| Spotify analytics | Cabinet `spotipy.last_success` (stale if &gt; 24h) |
+| Warnings / errors (24h) | Prefer Cabinet **Loki** (`log_query_issues_loki`) so rainbow sees cloud logs after Mongo log removal; fall back to local files |
+
+The detailed warnings/errors section below the scorecard uses the same query, rendered as a compact level/message table.
 
 ## dependencies
 - requests (`pip install requests`)
 - [cabinet](https://pypi.org/project/cabinet/)
 - Data comes from logs or information in `cabinet` produced by `../weather.py`
+
+## usage
+
+```bash
+python3 main.py           # send email
+python3 main.py --dry-run # print plain-text preview
+```

--- a/dailystatus/README.md
+++ b/dailystatus/README.md
@@ -3,19 +3,23 @@
 - Backs up logs, crontab, etc.
 - Sends me an email each day with my home automation status, the weather forecast, Spotify information, and anything else I find useful
 
+## Email layout
+
+1. Greeting + casual tomorrow weather (`68 and partly cloudy tomorrow`) from Cabinet `weather.data`
+2. **Personal SRE Scorecard** table
+3. Other sections (foodlog, Spotify details, warnings table, …)
+
 ## Personal SRE scorecard
 
-Every email starts with a **Personal SRE Scorecard** HTML table. Fields (missing data → `unknown / not configured`, never crash the email):
+Fields (missing data → `unknown / not configured`, never crash the email):
 
 | Check | Source |
 |-------|--------|
 | Borg backups | `borg list` on `keys.borg.repo` (+ recent `~/.cabinet/log/borg-errors`) |
-| Cloud / Rainbow drift | Cabinet `quality.<host>.updated_at` / `free_gb` from `quality/service_check.py` |
-| SSL expiry | TLS `notAfter` for common `*.tyler.cloud` hosts |
-| Disk free space | Same `quality` data (folded into the scorecard) |
+| Disk free space | Cabinet `quality.<host>.free_gb` from `quality/service_check.py` |
 | Pi-hole | Local Docker `pihole` container + `pihole status` when available |
-| Rainbow | Ping host from `path.rainbow-borg`, quality row, local uptime if hostname is `rainbow` |
-| Spotify analytics | Cabinet `spotipy.last_success` (stale if &gt; 24h) |
+| Rainbow | Ping host from `path.rainbow-borg`; `quality.rainbow.updated_at` as “last health check”; uptime when running on rainbow |
+| Spotify analytics | `Checked <age>; <n> songs.` from `spotipy.last_success` / `total_tracks` (stale if &gt; 24h) |
 | Warnings / errors (24h) | Prefer Cabinet **Loki** (`log_query_issues_loki`) so rainbow sees cloud logs after Mongo log removal; fall back to local files |
 
 The detailed warnings/errors section below the scorecard uses the same query, rendered as a compact level/message table.

--- a/dailystatus/main.py
+++ b/dailystatus/main.py
@@ -62,7 +62,7 @@ def run_service_check():
 
 def append_sre_scorecard(email, issue_lines=None, issue_source=None):
     """
-    Append the Personal SRE scorecard (Borg, drift, SSL, disk, Pi-hole,
+    Append the Metrics (Borg, drift, SSL, disk, Pi-hole,
     Rainbow, Spotify freshness, warnings summary).
     """
     try:
@@ -75,8 +75,8 @@ def append_sre_scorecard(email, issue_lines=None, issue_source=None):
     except Exception as e:  # pylint: disable=broad-exception-caught
         cab.log(f"SRE scorecard failed: {e}", level="error")
         fallback = (
-            "<h3>Personal SRE Scorecard</h3>"
-            "<p>Scorecard unavailable (see logs). "
+            "<h3>Metrics</h3>"
+            "<p>Metrics unavailable (see logs). "
             "Individual checks may show as unknown / not configured.</p><br>"
         )
         if issue_lines is None or issue_source is None:
@@ -644,9 +644,10 @@ def append_spotify_info(today, log_path_today, email):  # pylint: disable=redefi
 
 def format_casual_tomorrow_weather(weather_data=None) -> str | None:
     """
-    Casual one-liner like ``68 and partly cloudy tomorrow``.
+    Casual one-liner like ``68° and partly cloudy tomorrow``.
 
     Uses Cabinet ``weather.data.tomorrow_high`` + ``tomorrow_conditions``.
+    Caller wraps with bold ``Weather is`` lead-in for the email.
     """
     if weather_data is None:
         weather_data = cab.get("weather", "data") or {}
@@ -664,7 +665,7 @@ def format_casual_tomorrow_weather(weather_data=None) -> str | None:
     if not cond:
         return None
     cond = cond.lower()
-    return f"{high_n} and {cond} tomorrow"
+    return f"{high_n}\u00b0 and {cond} tomorrow"
 
 
 def append_weather_info(email):
@@ -743,7 +744,7 @@ if __name__ == "__main__":
     weather_line = format_casual_tomorrow_weather()
     if weather_line:
         status_email = (
-            f"Dear Tyler,<br><br>{html.escape(weather_line)}.<br><br>"
+            f"Dear Tyler,<br><br><b>Weather</b> is {html.escape(weather_line)}.<br><br>"
             "This is your daily status report.<br><br>"
         )
     else:

--- a/dailystatus/main.py
+++ b/dailystatus/main.py
@@ -642,8 +642,33 @@ def append_spotify_info(today, log_path_today, email):  # pylint: disable=redefi
     return email, last_success_stale
 
 
+def format_casual_tomorrow_weather(weather_data=None) -> str | None:
+    """
+    Casual one-liner like ``68 and partly cloudy tomorrow``.
+
+    Uses Cabinet ``weather.data.tomorrow_high`` + ``tomorrow_conditions``.
+    """
+    if weather_data is None:
+        weather_data = cab.get("weather", "data") or {}
+    if not isinstance(weather_data, dict):
+        return None
+    high = weather_data.get("tomorrow_high")
+    conditions = weather_data.get("tomorrow_conditions")
+    if high is None or not conditions:
+        return None
+    try:
+        high_n = int(round(float(high)))
+    except (TypeError, ValueError):
+        return None
+    cond = str(conditions).strip()
+    if not cond:
+        return None
+    cond = cond.lower()
+    return f"{high_n} and {cond} tomorrow"
+
+
 def append_weather_info(email):
-    """append weather data"""
+    """Append detailed weather block (legacy; prefer casual lead-in)."""
     weather_tomorrow_formatted = cab.get("weather", "data", "tomorrow_formatted") or {}
     if weather_tomorrow_formatted:
         email += f"""
@@ -715,7 +740,14 @@ if __name__ == "__main__":
     log_path_today = os.path.join(cab.path_dir_log, str(today))
 
     # set up email content
-    status_email = "Dear Tyler,<br><br>This is your daily status report.<br><br>"
+    weather_line = format_casual_tomorrow_weather()
+    if weather_line:
+        status_email = (
+            f"Dear Tyler,<br><br>{html.escape(weather_line)}.<br><br>"
+            "This is your daily status report.<br><br>"
+        )
+    else:
+        status_email = "Dear Tyler,<br><br>This is your daily status report.<br><br>"
 
     # run service check first to gather latest data
     run_service_check()
@@ -747,9 +779,6 @@ if __name__ == "__main__":
         has_errors = True
         # Stale Spotify success is not a food-log-only failure
         is_only_food_log_error = False
-
-    # append weather info
-    status_email = append_weather_info(status_email)
 
     # append service check summary
     status_email = append_service_check_summary(status_email)

--- a/dailystatus/main.py
+++ b/dailystatus/main.py
@@ -19,6 +19,13 @@ from pathlib import Path
 import cabinet
 from tyler_python_helpers import ChatGPT
 
+from scorecard import (
+    build_scorecard_rows,
+    collect_log_issues,
+    render_issues_html,
+    render_scorecard_html,
+)
+
 # initialize cabinet for configuration and mail for notifications
 cab = cabinet.Cabinet()
 mail = cabinet.Mail()
@@ -53,69 +60,31 @@ def run_service_check():
         return False
 
 
-def append_free_space_info(email):
-    """Append free space information from all devices as a table"""
-    # Get all quality data from cabinet
-    quality_data = cab.get("quality", force_cache_update=True) or {}
-
-    if not quality_data:
-        email += """
-        <h3>Disk Space:</h3>
-        <p>No disk space data available</p>
-        <br>
-        """
-        return email
-
-    # Build HTML table
-    table_html = """
-    <h3>Disk Space:</h3>
-    <table border="1" style="border-collapse: collapse; width: 100%;">
-        <tr style="background-color: #f2f2f2;">
-            <th style="padding: 8px; text-align: left;">Device</th>
-            <th style="padding: 8px; text-align: left;">Free Space (GB)</th>
-        </tr>
+def append_sre_scorecard(email, issue_lines=None, issue_source=None):
     """
-
-    for device_name, device_data in quality_data.items():
-        # Handle nested structure from service check script
-        if isinstance(device_data, dict):
-            # Check if it has the nested structure from service check
-            if "free_gb" in device_data:
-                free_gb = device_data["free_gb"]
-            else:
-                # Try to get free_gb directly from device_data
-                free_gb = device_data
-        else:
-            # Direct value
-            free_gb = device_data
-
-        # Ensure free_gb is a number
-        try:
-            free_gb = float(free_gb)
-        except (ValueError, TypeError):
-            continue
-
-        # Color code based on available space
-        if free_gb < 10:
-            row_style = "background-color: #ffebee; color: #c62828;"
-        elif free_gb < 50:
-            row_style = "background-color: #fff3e0; color: #ef6c00;"
-        else:
-            row_style = "background-color: #e8f5e8; color: #2e7d32;"
-
-        table_html += f"""
-    <tr style="{row_style}">
-        <td style="padding: 8px;">{device_name}</td>
-        <td style="padding: 8px;">{free_gb:.2f}</td>
-    </tr>
-        """
-
-    table_html += """
-    </table>
-    <br>
+    Append the Personal SRE scorecard (Borg, drift, SSL, disk, Pi-hole,
+    Rainbow, Spotify freshness, warnings summary).
     """
-
-    return email + table_html
+    try:
+        rows, issue_lines, issue_source = build_scorecard_rows(
+            cab,
+            issue_lines=issue_lines,
+            issue_source=issue_source,
+        )
+        return email + render_scorecard_html(rows), issue_lines, issue_source
+    except Exception as e:  # pylint: disable=broad-exception-caught
+        cab.log(f"SRE scorecard failed: {e}", level="error")
+        fallback = (
+            "<h3>Personal SRE Scorecard</h3>"
+            "<p>Scorecard unavailable (see logs). "
+            "Individual checks may show as unknown / not configured.</p><br>"
+        )
+        if issue_lines is None or issue_source is None:
+            try:
+                issue_lines, issue_source = collect_log_issues(cab)
+            except Exception:  # pylint: disable=broad-exception-caught
+                issue_lines, issue_source = [], "unavailable"
+        return email + fallback, issue_lines or [], issue_source or "unavailable"
 
 
 def append_service_check_summary(email):
@@ -574,31 +543,30 @@ def append_syncthing_conflict_check(email):
     return email + "<br>".join(html_diffs)
 
 
-def analyze_logs(email):
-    """Append warning/error/critical log lines from the last 24h via ``cab.log_query_issues()``."""
-    daily_log_issues = cab.log_query_issues()
-    is_warnings = any("WARN" in issue for issue in daily_log_issues)
+def analyze_logs(email, issue_lines=None, issue_source=None):
+    """
+    Append warning/error/critical log lines from the last 24h.
+
+    Prefers Loki (``log_query_issues_loki``) when configured so rainbow can see
+    cloud issues after Cabinet stopped storing logs in MongoDB; falls back to
+    local daily files.
+    """
+    if issue_lines is None or issue_source is None:
+        issue_lines, issue_source = collect_log_issues(cab)
+
+    is_warnings = any("WARN" in issue for issue in issue_lines)
     is_errors = any(
-        "ERROR" in issue or "CRITICAL" in issue for issue in daily_log_issues
+        "ERROR" in issue or "CRITICAL" in issue for issue in issue_lines
     )
 
     error_lines = [
-        line for line in daily_log_issues if "ERROR" in line or "CRITICAL" in line
+        line for line in issue_lines if "ERROR" in line or "CRITICAL" in line
     ]
     only_food_log_error = len(error_lines) == 1 and any(
         "No food logged for today." in line for line in error_lines
     )
 
-    if daily_log_issues:
-        daily_log_filtered = "<br>".join(daily_log_issues)
-        email += textwrap.dedent(
-            f"""
-            <h3>Warning/Error/Critical Log (24h):</h3>
-            <pre style="font-family: monospace; white-space: pre-wrap;">{daily_log_filtered}</pre>
-            <br>
-            """
-        )
-
+    email += render_issues_html(issue_lines, issue_source)
     return email, is_warnings, is_errors, only_food_log_error
 
 
@@ -752,6 +720,9 @@ if __name__ == "__main__":
     # run service check first to gather latest data
     run_service_check()
 
+    # SRE scorecard first (also collects cross-host issues via Loki when configured)
+    status_email, log_issues, log_issue_source = append_sre_scorecard(status_email)
+
     # check if food has been logged today
     status_email = append_food_log(status_email, dry_run=args.dry_run)
 
@@ -767,9 +738,9 @@ if __name__ == "__main__":
         today, log_path_today, status_email
     )
 
-    # analyze logs (24h via cab.log_query when Mongo enabled, else log files)
+    # analyze logs (Loki preferred; reuse scorecard query)
     status_email, has_warnings, has_errors, is_only_food_log_error = analyze_logs(
-        status_email
+        status_email, issue_lines=log_issues, issue_source=log_issue_source
     )
 
     if spotify_last_success_stale:
@@ -779,9 +750,6 @@ if __name__ == "__main__":
 
     # append weather info
     status_email = append_weather_info(status_email)
-
-    # append free space info
-    status_email = append_free_space_info(status_email)
 
     # append service check summary
     status_email = append_service_check_summary(status_email)

--- a/dailystatus/scorecard.py
+++ b/dailystatus/scorecard.py
@@ -415,10 +415,14 @@ def check_spotify(cab, now: datetime.datetime) -> ScorecardRow:
 
     avg_year = stats.get("average_year")
     try:
-        avg_year_n = int(round(float(avg_year))) if avg_year is not None else None
+        avg_year_f = float(avg_year) if avg_year is not None else None
     except (TypeError, ValueError):
-        avg_year_n = None
-    year_bit = f"avg year {avg_year_n}" if avg_year_n is not None else "avg year unknown"
+        avg_year_f = None
+    if avg_year_f is not None:
+        # Preserve full precision from Cabinet (e.g. 2009.366515837104)
+        year_bit = f"avg year {avg_year_f}"
+    else:
+        year_bit = "avg year unknown"
 
     if parsed is None:
         return ScorecardRow(
@@ -531,13 +535,7 @@ def render_scorecard_html(rows: list[ScorecardRow]) -> str:
 
 # Grafana Explore: Loki warnings (last 12h), used when the email has issues.
 GRAFANA_LOKI_WARNINGS_URL = (
-    "https://grafana.tyler.cloud/explore?schemaVersion=1&panes=%7B%22ieb%22:%7B%22"
-    "datasource%22:%22loki%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22"
-    "%7Blevel%3D%5C%22warning%5C%22%7D%20%7C%3D%20%60%60%22,%22queryType%22:%22range"
-    "%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22loki%22%7D,%22"
-    "editorMode%22:%22builder%22,%22direction%22:%22backward%22%7D%5D,%22range%22:%7B"
-    "%22from%22:%22now-12h%22,%22to%22:%22now%22%7D,%22panelsState%22:%7B%22logs%22:"
-    "%7B%22sortOrder%22:%22Descending%22%7D%7D,%22compact%22:false%7D%7D&orgId=1"
+    "https://grafana.tyler.cloud/explore"
 )
 
 

--- a/dailystatus/scorecard.py
+++ b/dailystatus/scorecard.py
@@ -1,8 +1,8 @@
 """
 Personal SRE scorecard for the daily status email (TJW-316).
 
-Reads existing Cabinet keys, Borg archives, local service checks, and SSL
-handshakes. Missing data becomes status=unknown rather than raising.
+Reads existing Cabinet keys, Borg archives, and local service checks.
+Missing data becomes status=unknown rather than raising.
 """
 
 from __future__ import annotations
@@ -10,23 +10,10 @@ from __future__ import annotations
 import datetime
 import os
 import re
-import socket
-import ssl
 import subprocess
 from dataclasses import dataclass
 from typing import Any, Callable
 from urllib.parse import urlparse
-
-# Hosts probed for TLS expiry (Cloudflare-fronted tyler.cloud services).
-DEFAULT_SSL_HOSTS = (
-    "tyler.cloud",
-    "git.tyler.cloud",
-    "photos.tyler.cloud",
-    "affine.tyler.cloud",
-    "auth.tyler.cloud",
-    "vault.tyler.cloud",
-    "notes.tyler.cloud",
-)
 
 _BORG_ARCHIVE_RE = re.compile(
     r"^(?P<label>.+)-(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$"
@@ -266,107 +253,6 @@ def check_borg(cab, now: datetime.datetime) -> ScorecardRow:
     return ScorecardRow("Borg backups", status, detail)
 
 
-def check_host_drift(quality_data: dict, host: str, now: datetime.datetime) -> ScorecardRow:
-    label = f"{host.title()} drift"
-    device = quality_data.get(host) if isinstance(quality_data, dict) else None
-    if not isinstance(device, dict):
-        return ScorecardRow(label, "unknown", "unknown / not configured")
-
-    updated_raw = device.get("updated_at")
-    updated = parse_quality_updated_at(updated_raw, now=now)
-    free_gb = device.get("free_gb")
-    try:
-        free_gb_f = float(free_gb) if free_gb is not None else None
-    except (TypeError, ValueError):
-        free_gb_f = None
-
-    parts: list[str] = []
-    if updated is None:
-        parts.append(f"updated_at={_safe_str(updated_raw)}")
-        status = "unknown"
-    else:
-        hours = age_hours(updated, now)
-        parts.append(f"quality {format_age_hours(hours)}")
-        if hours > 72:
-            status = "error"
-        elif hours > 36:
-            status = "warn"
-        else:
-            status = "ok"
-
-    if free_gb_f is not None:
-        parts.append(f"{free_gb_f:.1f} GB free")
-        if free_gb_f < 10:
-            status = "error"
-        elif free_gb_f < 50 and status == "ok":
-            status = "warn"
-    else:
-        parts.append("disk free unknown / not configured")
-        if status == "ok":
-            status = "unknown"
-
-    return ScorecardRow(label, status, "; ".join(parts))
-
-
-def check_ssl_expiry(
-    hosts: tuple[str, ...] | list[str] = DEFAULT_SSL_HOSTS,
-    *,
-    now: datetime.datetime | None = None,
-    warn_days: int = 30,
-    error_days: int = 14,
-) -> ScorecardRow:
-    now = now or datetime.datetime.now(datetime.timezone.utc)
-    if now.tzinfo is None:
-        now_aware = now.replace(tzinfo=datetime.timezone.utc)
-    else:
-        now_aware = now.astimezone(datetime.timezone.utc)
-
-    results: list[tuple[str, int | None, str | None]] = []
-    for host in hosts:
-        try:
-            ctx = ssl.create_default_context()
-            with socket.create_connection((host, 443), timeout=5) as sock:
-                with ctx.wrap_socket(sock, server_hostname=host) as ssock:
-                    cert = ssock.getpeercert()
-            not_after = cert.get("notAfter")
-            if not not_after:
-                results.append((host, None, "no notAfter"))
-                continue
-            expiry = datetime.datetime.strptime(
-                not_after, "%b %d %H:%M:%S %Y %Z"
-            ).replace(tzinfo=datetime.timezone.utc)
-            days = (expiry - now_aware).days
-            results.append((host, days, None))
-        except Exception as exc:  # pylint: disable=broad-exception-caught
-            results.append((host, None, f"{type(exc).__name__}"))
-
-    if not results:
-        return ScorecardRow("SSL expiry", "unknown", "unknown / not configured")
-
-    ok_hosts = [(h, d) for h, d, err in results if err is None and d is not None]
-    fail_hosts = [(h, err) for h, d, err in results if err is not None]
-
-    if not ok_hosts:
-        detail = "all probes failed: " + ", ".join(f"{h} ({e})" for h, e in fail_hosts[:4])
-        return ScorecardRow("SSL expiry", "unknown", detail)
-
-    soonest_host, soonest_days = min(ok_hosts, key=lambda item: item[1])
-    detail = f"soonest {soonest_host} in {soonest_days}d"
-    if fail_hosts:
-        detail += f"; {len(fail_hosts)} host(s) unreachable"
-
-    if soonest_days < 0:
-        status = "error"
-        detail = f"EXPIRED: {soonest_host} ({soonest_days}d)"
-    elif soonest_days <= error_days:
-        status = "error"
-    elif soonest_days <= warn_days:
-        status = "warn"
-    else:
-        status = "ok"
-    return ScorecardRow("SSL expiry", status, detail)
-
-
 def check_disk_summary(quality_data: dict) -> ScorecardRow:
     if not isinstance(quality_data, dict) or not quality_data:
         return ScorecardRow("Disk free space", "unknown", "unknown / not configured")
@@ -459,6 +345,7 @@ def ping_host(hostname: str, timeout_s: int = 3) -> bool:
 
 
 def check_rainbow(cab, quality_data: dict, now: datetime.datetime) -> ScorecardRow:
+    """Reachability + uptime; disk free lives in the Disk free space row."""
     host = rainbow_host_from_borg_path(cab.get("path", "rainbow-borg"))
     reachable = None
     if host:
@@ -470,9 +357,9 @@ def check_rainbow(cab, quality_data: dict, now: datetime.datetime) -> ScorecardR
 
     if host:
         if reachable is True:
-            parts.append(f"reachable ({host})")
+            parts.append("reachable")
         elif reachable is False:
-            parts.append(f"unreachable ({host})")
+            parts.append("unreachable")
             status = "error"
     else:
         parts.append("host unknown / not configured")
@@ -480,24 +367,20 @@ def check_rainbow(cab, quality_data: dict, now: datetime.datetime) -> ScorecardR
 
     if isinstance(device, dict):
         updated = parse_quality_updated_at(device.get("updated_at"), now=now)
-        free_gb = device.get("free_gb")
         if updated is not None:
             hours = age_hours(updated, now)
-            parts.append(f"quality {format_age_hours(hours)}")
+            # service_check writes quality.rainbow.updated_at on rainbow
+            parts.append(f"last health check {format_age_hours(hours)}")
             if hours > 72 and status != "error":
                 status = "error"
             elif hours > 36 and status == "ok":
                 status = "warn"
         else:
-            parts.append("quality updated_at unknown")
+            parts.append("last health check unknown")
             if status == "ok":
                 status = "unknown"
-        try:
-            parts.append(f"{float(free_gb):.1f} GB free")
-        except (TypeError, ValueError):
-            pass
     else:
-        parts.append("no quality.rainbow data")
+        parts.append("no recent health check")
         if status == "ok":
             status = "unknown"
 
@@ -507,7 +390,7 @@ def check_rainbow(cab, quality_data: dict, now: datetime.datetime) -> ScorecardR
             with open("/proc/uptime", "r", encoding="utf-8") as fh:
                 seconds = float(fh.read().split()[0])
             days = seconds / 86400.0
-            parts.append(f"uptime {days:.1f}d")
+            parts.append(f"uptime {days:.0f}d")
     except (OSError, ValueError, AttributeError):
         pass
 
@@ -523,14 +406,23 @@ def check_spotify(cab, now: datetime.datetime) -> ScorecardRow:
         stats = {}
     raw = stats.get("last_success")
     parsed = parse_spotify_last_success(raw)
+    tracks = stats.get("total_tracks")
+    try:
+        tracks_n = int(tracks) if tracks is not None else None
+    except (TypeError, ValueError):
+        tracks_n = None
+    songs_bit = f"{tracks_n} songs" if tracks_n is not None else "song count unknown"
+
     if parsed is None:
         return ScorecardRow(
             "Spotify analytics",
             "error" if raw else "unknown",
-            f"last_success={_safe_str(raw)}",
+            f"Checked unknown; {songs_bit}."
+            if not raw
+            else f"Checked unknown ({_safe_str(raw)}); {songs_bit}.",
         )
     hours = age_hours(parsed, now)
-    detail = f"last_success {raw} ({format_age_hours(hours)})"
+    detail = f"Checked {format_age_hours(hours)}; {songs_bit}."
     if hours > 48:
         status = "error"
     elif hours > 24:
@@ -573,7 +465,6 @@ def build_scorecard_rows(
     quality_data: dict | None = None,
     issue_lines: list[str] | None = None,
     issue_source: str | None = None,
-    ssl_hosts: tuple[str, ...] | list[str] = DEFAULT_SSL_HOSTS,
 ) -> tuple[list[ScorecardRow], list[str], str]:
     """
     Collect scorecard rows plus the issue lines used for the warnings section.
@@ -596,9 +487,6 @@ def build_scorecard_rows(
 
     rows = [
         check_borg(cab, now),
-        check_host_drift(quality_data, "cloud", now),
-        check_host_drift(quality_data, "rainbow", now),
-        check_ssl_expiry(ssl_hosts, now=now),
         check_disk_summary(quality_data),
         check_pihole(),
         check_rainbow(cab, quality_data, now),

--- a/dailystatus/scorecard.py
+++ b/dailystatus/scorecard.py
@@ -1,5 +1,5 @@
 """
-Personal SRE scorecard for the daily status email (TJW-316).
+Personal Metrics for the daily status email (TJW-316).
 
 Reads existing Cabinet keys, Borg archives, and local service checks.
 Missing data becomes status=unknown rather than raising.
@@ -413,16 +413,23 @@ def check_spotify(cab, now: datetime.datetime) -> ScorecardRow:
         tracks_n = None
     songs_bit = f"{tracks_n} songs" if tracks_n is not None else "song count unknown"
 
+    avg_year = stats.get("average_year")
+    try:
+        avg_year_n = int(round(float(avg_year))) if avg_year is not None else None
+    except (TypeError, ValueError):
+        avg_year_n = None
+    year_bit = f"avg year {avg_year_n}" if avg_year_n is not None else "avg year unknown"
+
     if parsed is None:
         return ScorecardRow(
             "Spotify analytics",
             "error" if raw else "unknown",
-            f"Checked unknown; {songs_bit}."
+            f"Checked unknown; {songs_bit}; {year_bit}."
             if not raw
-            else f"Checked unknown ({_safe_str(raw)}); {songs_bit}.",
+            else f"Checked unknown ({_safe_str(raw)}); {songs_bit}; {year_bit}.",
         )
     hours = age_hours(parsed, now)
-    detail = f"Checked {format_age_hours(hours)}; {songs_bit}."
+    detail = f"Checked {format_age_hours(hours)}; {songs_bit}; {year_bit}."
     if hours > 48:
         status = "error"
     elif hours > 24:
@@ -446,7 +453,7 @@ def check_warnings_summary(issue_lines: list[str], source: str) -> ScorecardRow:
     ]
     warnings = [line for line in issue_lines if "WARN" in line.upper()]
     detail = (
-        f"{len(errors)} error(s), {len(warnings)} warning(s) via {source}"
+        f"{len(errors)} error(s), {len(warnings)} warning(s) (source: {source})"
     )
     if errors:
         status = "error"
@@ -454,7 +461,7 @@ def check_warnings_summary(issue_lines: list[str], source: str) -> ScorecardRow:
         status = "warn"
     else:
         status = "ok"
-        detail = f"none via {source}"
+        detail = f"none (source: {source})"
     return ScorecardRow("Warnings / errors (24h)", status, detail)
 
 
@@ -499,7 +506,7 @@ def build_scorecard_rows(
 def render_scorecard_html(rows: list[ScorecardRow]) -> str:
     """Compact HTML table for the daily status email."""
     table = [
-        "<h3>Personal SRE Scorecard</h3>",
+        "<h3>Personal Metrics</h3>",
         '<table border="1" style="border-collapse: collapse; width: 100%;">',
         '<tr style="background-color: #f2f2f2;">',
         '<th style="padding: 8px; text-align: left;">Check</th>',
@@ -522,12 +529,32 @@ def render_scorecard_html(rows: list[ScorecardRow]) -> str:
     return "\n".join(table)
 
 
+# Grafana Explore: Loki warnings (last 12h), used when the email has issues.
+GRAFANA_LOKI_WARNINGS_URL = (
+    "https://grafana.tyler.cloud/explore?schemaVersion=1&panes=%7B%22ieb%22:%7B%22"
+    "datasource%22:%22loki%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22"
+    "%7Blevel%3D%5C%22warning%5C%22%7D%20%7C%3D%20%60%60%22,%22queryType%22:%22range"
+    "%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22loki%22%7D,%22"
+    "editorMode%22:%22builder%22,%22direction%22:%22backward%22%7D%5D,%22range%22:%7B"
+    "%22from%22:%22now-12h%22,%22to%22:%22now%22%7D,%22panelsState%22:%7B%22logs%22:"
+    "%7B%22sortOrder%22:%22Descending%22%7D%7D,%22compact%22:false%7D%7D&orgId=1"
+)
+
+
+def _source_note_html(source: str, *, has_issues: bool) -> str:
+    """Build ``(source: loki)`` note; link Loki to Grafana when there are issues."""
+    if has_issues and source == "loki":
+        href = _escape(GRAFANA_LOKI_WARNINGS_URL)
+        return f'(source: <a href="{href}">loki</a>)'
+    return f"(source: {_escape(source)})"
+
+
 def render_issues_html(issue_lines: list[str], source: str, limit: int = 40) -> str:
     """Visually cleaned-up warnings/errors section (replaces raw pre dump)."""
     if not issue_lines:
         return (
             "<h3>Warnings / Errors (24h)</h3>"
-            f"<p>None detected via { _escape(source) }.</p><br>"
+            f"<p>None detected via {_escape(source)}.</p><br>"
         )
 
     shown = issue_lines[-limit:]
@@ -553,11 +580,14 @@ def render_issues_html(issue_lines: list[str], source: str, limit: int = 40) -> 
         )
 
     omitted = max(0, len(issue_lines) - len(shown))
-    note = ""
+    source_note = _source_note_html(source, has_issues=True)
     if omitted:
-        note = f"<p>Showing latest {len(shown)} of {len(issue_lines)} (source: {_escape(source)}).</p>"
+        note = (
+            f"<p>Showing latest {len(shown)} of {len(issue_lines)} "
+            f"{source_note}.</p>"
+        )
     else:
-        note = f"<p>Source: {_escape(source)}.</p>"
+        note = f"<p>{source_note}.</p>"
 
     return (
         "<h3>Warnings / Errors (24h)</h3>"

--- a/dailystatus/scorecard.py
+++ b/dailystatus/scorecard.py
@@ -1,0 +1,694 @@
+"""
+Personal SRE scorecard for the daily status email (TJW-316).
+
+Reads existing Cabinet keys, Borg archives, local service checks, and SSL
+handshakes. Missing data becomes status=unknown rather than raising.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import re
+import socket
+import ssl
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib.parse import urlparse
+
+# Hosts probed for TLS expiry (Cloudflare-fronted tyler.cloud services).
+DEFAULT_SSL_HOSTS = (
+    "tyler.cloud",
+    "git.tyler.cloud",
+    "photos.tyler.cloud",
+    "affine.tyler.cloud",
+    "auth.tyler.cloud",
+    "vault.tyler.cloud",
+    "notes.tyler.cloud",
+)
+
+_BORG_ARCHIVE_RE = re.compile(
+    r"^(?P<label>.+)-(?P<ts>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$"
+)
+_QUALITY_TS_RE = re.compile(
+    r"^(?P<dt>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})(?:\s+\S+)?$"
+)
+
+_STATUS_STYLES = {
+    "ok": "background-color: #e8f5e8; color: #2e7d32;",
+    "warn": "background-color: #fff3e0; color: #ef6c00;",
+    "error": "background-color: #ffebee; color: #c62828;",
+    "unknown": "background-color: #f5f5f5; color: #616161;",
+}
+
+
+@dataclass(frozen=True)
+class ScorecardRow:
+    """One row in the SRE scorecard table."""
+
+    check: str
+    status: str  # ok | warn | error | unknown
+    detail: str
+
+
+def _safe_str(value: Any, default: str = "unknown / not configured") -> str:
+    if value is None or value == "":
+        return default
+    return str(value)
+
+
+def parse_quality_updated_at(
+    value: Any, now: datetime.datetime | None = None
+) -> datetime.datetime | None:
+    """Parse ``quality.<host>.updated_at`` (``YYYY-MM-DD HH:MM:SS TZ``)."""
+    if not value:
+        return None
+    text = str(value).strip()
+    match = _QUALITY_TS_RE.match(text)
+    if not match:
+        return None
+    try:
+        return datetime.datetime.strptime(match.group("dt"), "%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return None
+
+
+def parse_borg_archive_name(name: str) -> datetime.datetime | None:
+    """Parse ``cloud-2026-08-10T03:05:37`` style Borg archive names."""
+    match = _BORG_ARCHIVE_RE.match(name.strip())
+    if not match:
+        return None
+    try:
+        return datetime.datetime.strptime(match.group("ts"), "%Y-%m-%dT%H:%M:%S")
+    except ValueError:
+        return None
+
+
+def parse_spotify_last_success(value: Any) -> datetime.datetime | None:
+    """Parse ``spotipy.last_success`` (``YYYY-MM-DD HH:mm``)."""
+    if not value:
+        return None
+    try:
+        return datetime.datetime.strptime(str(value), "%Y-%m-%d %H:%M")
+    except (TypeError, ValueError):
+        return None
+
+
+def expand_borg_repo_path(raw: str | None) -> str | None:
+    """Expand ``$HOME`` / ``~`` in a Cabinet Borg repo path."""
+    if not raw:
+        return None
+    text = str(raw).strip()
+    if not text:
+        return None
+    home = os.path.expanduser("~")
+    text = text.replace("$HOME", home)
+    return os.path.expanduser(text)
+
+
+def rainbow_host_from_borg_path(raw: str | None) -> str | None:
+    """
+    Extract SSH host from ``path.rainbow-borg`` (``ssh://user@host:port/path``).
+    """
+    if not raw:
+        return None
+    text = str(raw).strip()
+    if not text.startswith("ssh://"):
+        return None
+    parsed = urlparse(text)
+    return parsed.hostname
+
+
+def age_hours(then: datetime.datetime, now: datetime.datetime) -> float:
+    return (now - then).total_seconds() / 3600.0
+
+
+def format_age_hours(hours: float) -> str:
+    if hours < 1:
+        return f"{hours * 60:.0f}m ago"
+    if hours < 48:
+        return f"{hours:.0f}h ago"
+    return f"{hours / 24:.1f}d ago"
+
+
+def collect_log_issues(cab) -> tuple[list[str], str]:
+    """
+    Return (issue lines, source label).
+
+    Prefer Loki (cross-host, post-Mongo log migration) when ``logging.loki_url``
+    is configured; fall back to local daily files.
+
+    If the configured Loki URL fails (common on the Loki host when config uses a
+    Tailscale DNS name), retry ``http://127.0.0.1:3100``.
+    """
+    loki_url = getattr(cab, "logging_loki_url", None) or ""
+    candidates: list[str] = []
+    if isinstance(loki_url, str) and loki_url.strip():
+        candidates.append(loki_url.strip().rstrip("/"))
+    localhost = "http://127.0.0.1:3100"
+    if localhost not in candidates:
+        candidates.append(localhost)
+
+    original = getattr(cab, "logging_loki_url", loki_url)
+    for url in candidates:
+        try:
+            cab.logging_loki_url = url
+            lines = cab.log_query_issues_loki() or []
+            return list(lines), "loki"
+        except Exception:  # pylint: disable=broad-exception-caught
+            continue
+        finally:
+            try:
+                cab.logging_loki_url = original
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+
+    try:
+        lines = cab.log_query_issues() or []
+        return list(lines), "local"
+    except Exception:  # pylint: disable=broad-exception-caught
+        return [], "unavailable"
+
+
+def _list_borg_archives(cab, timeout_s: float = 45.0) -> list[str] | None:
+    """Return short archive names newest-last, or None if Borg is unavailable."""
+    try:
+        repo = expand_borg_repo_path(cab.get("keys", "borg", "repo"))
+        passphrase = cab.get("keys", "borg", "passphrase")
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
+    if not repo or not passphrase:
+        return None
+    if not os.path.isdir(repo) and not str(repo).startswith("ssh://"):
+        return None
+
+    env = os.environ.copy()
+    env["BORG_REPO"] = repo
+    env["BORG_PASSPHRASE"] = str(passphrase)
+    # Avoid interactive prompts hanging cron/email.
+    env.setdefault("BORG_UNKNOWN_UNENCRYPTED_REPO_ACCESS_IS_OK", "yes")
+    env.setdefault("BORG_RELOCATED_REPO_ACCESS_IS_OK", "yes")
+
+    try:
+        result = subprocess.run(
+            ["borg", "list", "--short"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return None
+
+    if result.returncode != 0:
+        return None
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _recent_borg_error_files(max_age_days: int = 7) -> list[str]:
+    """Basenames of recent files under ``~/.cabinet/log/borg-errors``."""
+    err_dir = os.path.expanduser("~/.cabinet/log/borg-errors")
+    if not os.path.isdir(err_dir):
+        return []
+    cutoff = datetime.datetime.now() - datetime.timedelta(days=max_age_days)
+    found: list[str] = []
+    try:
+        for name in os.listdir(err_dir):
+            if "error" not in name.lower():
+                continue
+            path = os.path.join(err_dir, name)
+            try:
+                mtime = datetime.datetime.fromtimestamp(os.path.getmtime(path))
+            except OSError:
+                continue
+            if mtime >= cutoff:
+                found.append(name)
+    except OSError:
+        return []
+    found.sort(reverse=True)
+    return found
+
+
+def check_borg(cab, now: datetime.datetime) -> ScorecardRow:
+    archives = _list_borg_archives(cab)
+    error_files = _recent_borg_error_files()
+    if archives is None:
+        detail = "unknown / not configured (borg list unavailable)"
+        if error_files:
+            detail += f"; recent error logs: {', '.join(error_files[:3])}"
+        return ScorecardRow("Borg backups", "unknown", detail)
+
+    if not archives:
+        return ScorecardRow("Borg backups", "error", "no archives found")
+
+    last_name = archives[-1]
+    last_dt = parse_borg_archive_name(last_name)
+    if last_dt is None:
+        return ScorecardRow(
+            "Borg backups",
+            "warn",
+            f"latest archive {last_name!r} (unparseable timestamp)",
+        )
+
+    hours = age_hours(last_dt, now)
+    detail = f"last success {last_name} ({format_age_hours(hours)})"
+    if error_files:
+        detail += f"; recent failures logged: {', '.join(error_files[:2])}"
+
+    if hours > 72:
+        status = "error"
+    elif hours > 36 or error_files:
+        status = "warn"
+    else:
+        status = "ok"
+    return ScorecardRow("Borg backups", status, detail)
+
+
+def check_host_drift(quality_data: dict, host: str, now: datetime.datetime) -> ScorecardRow:
+    label = f"{host.title()} drift"
+    device = quality_data.get(host) if isinstance(quality_data, dict) else None
+    if not isinstance(device, dict):
+        return ScorecardRow(label, "unknown", "unknown / not configured")
+
+    updated_raw = device.get("updated_at")
+    updated = parse_quality_updated_at(updated_raw, now=now)
+    free_gb = device.get("free_gb")
+    try:
+        free_gb_f = float(free_gb) if free_gb is not None else None
+    except (TypeError, ValueError):
+        free_gb_f = None
+
+    parts: list[str] = []
+    if updated is None:
+        parts.append(f"updated_at={_safe_str(updated_raw)}")
+        status = "unknown"
+    else:
+        hours = age_hours(updated, now)
+        parts.append(f"quality {format_age_hours(hours)}")
+        if hours > 72:
+            status = "error"
+        elif hours > 36:
+            status = "warn"
+        else:
+            status = "ok"
+
+    if free_gb_f is not None:
+        parts.append(f"{free_gb_f:.1f} GB free")
+        if free_gb_f < 10:
+            status = "error"
+        elif free_gb_f < 50 and status == "ok":
+            status = "warn"
+    else:
+        parts.append("disk free unknown / not configured")
+        if status == "ok":
+            status = "unknown"
+
+    return ScorecardRow(label, status, "; ".join(parts))
+
+
+def check_ssl_expiry(
+    hosts: tuple[str, ...] | list[str] = DEFAULT_SSL_HOSTS,
+    *,
+    now: datetime.datetime | None = None,
+    warn_days: int = 30,
+    error_days: int = 14,
+) -> ScorecardRow:
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    if now.tzinfo is None:
+        now_aware = now.replace(tzinfo=datetime.timezone.utc)
+    else:
+        now_aware = now.astimezone(datetime.timezone.utc)
+
+    results: list[tuple[str, int | None, str | None]] = []
+    for host in hosts:
+        try:
+            ctx = ssl.create_default_context()
+            with socket.create_connection((host, 443), timeout=5) as sock:
+                with ctx.wrap_socket(sock, server_hostname=host) as ssock:
+                    cert = ssock.getpeercert()
+            not_after = cert.get("notAfter")
+            if not not_after:
+                results.append((host, None, "no notAfter"))
+                continue
+            expiry = datetime.datetime.strptime(
+                not_after, "%b %d %H:%M:%S %Y %Z"
+            ).replace(tzinfo=datetime.timezone.utc)
+            days = (expiry - now_aware).days
+            results.append((host, days, None))
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            results.append((host, None, f"{type(exc).__name__}"))
+
+    if not results:
+        return ScorecardRow("SSL expiry", "unknown", "unknown / not configured")
+
+    ok_hosts = [(h, d) for h, d, err in results if err is None and d is not None]
+    fail_hosts = [(h, err) for h, d, err in results if err is not None]
+
+    if not ok_hosts:
+        detail = "all probes failed: " + ", ".join(f"{h} ({e})" for h, e in fail_hosts[:4])
+        return ScorecardRow("SSL expiry", "unknown", detail)
+
+    soonest_host, soonest_days = min(ok_hosts, key=lambda item: item[1])
+    detail = f"soonest {soonest_host} in {soonest_days}d"
+    if fail_hosts:
+        detail += f"; {len(fail_hosts)} host(s) unreachable"
+
+    if soonest_days < 0:
+        status = "error"
+        detail = f"EXPIRED: {soonest_host} ({soonest_days}d)"
+    elif soonest_days <= error_days:
+        status = "error"
+    elif soonest_days <= warn_days:
+        status = "warn"
+    else:
+        status = "ok"
+    return ScorecardRow("SSL expiry", status, detail)
+
+
+def check_disk_summary(quality_data: dict) -> ScorecardRow:
+    if not isinstance(quality_data, dict) or not quality_data:
+        return ScorecardRow("Disk free space", "unknown", "unknown / not configured")
+
+    parts: list[str] = []
+    worst = "ok"
+    for name, device in quality_data.items():
+        free_gb = None
+        if isinstance(device, dict):
+            free_gb = device.get("free_gb", device)
+        else:
+            free_gb = device
+        try:
+            free_gb_f = float(free_gb)
+        except (TypeError, ValueError):
+            parts.append(f"{name}: unknown")
+            if worst == "ok":
+                worst = "unknown"
+            continue
+        parts.append(f"{name} {free_gb_f:.1f} GB")
+        if free_gb_f < 10:
+            worst = "error"
+        elif free_gb_f < 50 and worst == "ok":
+            worst = "warn"
+    return ScorecardRow("Disk free space", worst, "; ".join(parts) or "unknown / not configured")
+
+
+def check_pihole(
+    *,
+    run_command: Callable[[list[str]], tuple[int, str, str]] | None = None,
+) -> ScorecardRow:
+    """Check local Pi-hole container / blocking status when Docker is available."""
+
+    def _run(cmd: list[str]) -> tuple[int, str, str]:
+        if run_command is not None:
+            return run_command(cmd)
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=15, check=False
+            )
+            return result.returncode, result.stdout.strip(), result.stderr.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            return 127, "", str(exc)
+
+    code, out, _ = _run(
+        ["docker", "ps", "--filter", "name=pihole", "--format", "{{.Names}} {{.Status}}"]
+    )
+    if code != 0:
+        return ScorecardRow(
+            "Pi-hole",
+            "unknown",
+            "unknown / not configured (docker unavailable)",
+        )
+    if not out or "pihole" not in out.lower():
+        return ScorecardRow("Pi-hole", "error", "container not running")
+
+    status_line = out.splitlines()[0]
+    healthy = "up" in status_line.lower()
+    # Best-effort block health
+    b_code, b_out, _ = _run(["docker", "exec", "pihole", "pihole", "status"])
+    blocking = None
+    if b_code == 0 and b_out:
+        lower = b_out.lower()
+        if "blocking is enabled" in lower or "enabled" in lower:
+            blocking = True
+        elif "disabled" in lower:
+            blocking = False
+
+    if not healthy:
+        return ScorecardRow("Pi-hole", "error", status_line)
+    if blocking is False:
+        return ScorecardRow("Pi-hole", "warn", f"{status_line}; blocking disabled")
+    if blocking is True:
+        return ScorecardRow("Pi-hole", "ok", f"{status_line}; blocking enabled")
+    return ScorecardRow("Pi-hole", "ok", status_line)
+
+
+def ping_host(hostname: str, timeout_s: int = 3) -> bool:
+    try:
+        result = subprocess.run(
+            ["ping", "-c", "1", f"-W{timeout_s}", hostname],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s + 2,
+            check=False,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return False
+
+
+def check_rainbow(cab, quality_data: dict, now: datetime.datetime) -> ScorecardRow:
+    host = rainbow_host_from_borg_path(cab.get("path", "rainbow-borg"))
+    reachable = None
+    if host:
+        reachable = ping_host(host)
+
+    device = quality_data.get("rainbow") if isinstance(quality_data, dict) else None
+    parts: list[str] = []
+    status = "ok"
+
+    if host:
+        if reachable is True:
+            parts.append(f"reachable ({host})")
+        elif reachable is False:
+            parts.append(f"unreachable ({host})")
+            status = "error"
+    else:
+        parts.append("host unknown / not configured")
+        status = "unknown"
+
+    if isinstance(device, dict):
+        updated = parse_quality_updated_at(device.get("updated_at"), now=now)
+        free_gb = device.get("free_gb")
+        if updated is not None:
+            hours = age_hours(updated, now)
+            parts.append(f"quality {format_age_hours(hours)}")
+            if hours > 72 and status != "error":
+                status = "error"
+            elif hours > 36 and status == "ok":
+                status = "warn"
+        else:
+            parts.append("quality updated_at unknown")
+            if status == "ok":
+                status = "unknown"
+        try:
+            parts.append(f"{float(free_gb):.1f} GB free")
+        except (TypeError, ValueError):
+            pass
+    else:
+        parts.append("no quality.rainbow data")
+        if status == "ok":
+            status = "unknown"
+
+    # Local uptime when this host *is* rainbow
+    try:
+        if os.uname().nodename.lower() == "rainbow":
+            with open("/proc/uptime", "r", encoding="utf-8") as fh:
+                seconds = float(fh.read().split()[0])
+            days = seconds / 86400.0
+            parts.append(f"uptime {days:.1f}d")
+    except (OSError, ValueError, AttributeError):
+        pass
+
+    return ScorecardRow("Rainbow", status, "; ".join(parts))
+
+
+def check_spotify(cab, now: datetime.datetime) -> ScorecardRow:
+    try:
+        stats = cab.get("spotipy") or {}
+    except Exception:  # pylint: disable=broad-exception-caught
+        stats = {}
+    if not isinstance(stats, dict):
+        stats = {}
+    raw = stats.get("last_success")
+    parsed = parse_spotify_last_success(raw)
+    if parsed is None:
+        return ScorecardRow(
+            "Spotify analytics",
+            "error" if raw else "unknown",
+            f"last_success={_safe_str(raw)}",
+        )
+    hours = age_hours(parsed, now)
+    detail = f"last_success {raw} ({format_age_hours(hours)})"
+    if hours > 48:
+        status = "error"
+    elif hours > 24:
+        status = "warn"
+    else:
+        status = "ok"
+    return ScorecardRow("Spotify analytics", status, detail)
+
+
+def check_warnings_summary(issue_lines: list[str], source: str) -> ScorecardRow:
+    if source == "unavailable":
+        return ScorecardRow(
+            "Warnings / errors (24h)",
+            "unknown",
+            "unknown / not configured (log query failed)",
+        )
+    errors = [
+        line
+        for line in issue_lines
+        if "ERROR" in line.upper() or "CRITICAL" in line.upper()
+    ]
+    warnings = [line for line in issue_lines if "WARN" in line.upper()]
+    detail = (
+        f"{len(errors)} error(s), {len(warnings)} warning(s) via {source}"
+    )
+    if errors:
+        status = "error"
+    elif warnings:
+        status = "warn"
+    else:
+        status = "ok"
+        detail = f"none via {source}"
+    return ScorecardRow("Warnings / errors (24h)", status, detail)
+
+
+def build_scorecard_rows(
+    cab,
+    *,
+    now: datetime.datetime | None = None,
+    quality_data: dict | None = None,
+    issue_lines: list[str] | None = None,
+    issue_source: str | None = None,
+    ssl_hosts: tuple[str, ...] | list[str] = DEFAULT_SSL_HOSTS,
+) -> tuple[list[ScorecardRow], list[str], str]:
+    """
+    Collect scorecard rows plus the issue lines used for the warnings section.
+
+    Returns ``(rows, issue_lines, issue_source)``.
+    """
+    now = now or datetime.datetime.now()
+    if quality_data is None:
+        try:
+            quality_data = cab.get("quality", force_cache_update=True) or {}
+        except TypeError:
+            quality_data = cab.get("quality") or {}
+        except Exception:  # pylint: disable=broad-exception-caught
+            quality_data = {}
+    if not isinstance(quality_data, dict):
+        quality_data = {}
+
+    if issue_lines is None or issue_source is None:
+        issue_lines, issue_source = collect_log_issues(cab)
+
+    rows = [
+        check_borg(cab, now),
+        check_host_drift(quality_data, "cloud", now),
+        check_host_drift(quality_data, "rainbow", now),
+        check_ssl_expiry(ssl_hosts, now=now),
+        check_disk_summary(quality_data),
+        check_pihole(),
+        check_rainbow(cab, quality_data, now),
+        check_spotify(cab, now),
+        check_warnings_summary(issue_lines, issue_source),
+    ]
+    return rows, issue_lines, issue_source
+
+
+def render_scorecard_html(rows: list[ScorecardRow]) -> str:
+    """Compact HTML table for the daily status email."""
+    table = [
+        "<h3>Personal SRE Scorecard</h3>",
+        '<table border="1" style="border-collapse: collapse; width: 100%;">',
+        '<tr style="background-color: #f2f2f2;">',
+        '<th style="padding: 8px; text-align: left;">Check</th>',
+        '<th style="padding: 8px; text-align: left;">Status</th>',
+        '<th style="padding: 8px; text-align: left;">Detail</th>',
+        "</tr>",
+    ]
+    for row in rows:
+        style = _STATUS_STYLES.get(row.status, _STATUS_STYLES["unknown"])
+        table.append(f'<tr style="{style}">')
+        table.append(f'<td style="padding: 8px;">{_escape(row.check)}</td>')
+        table.append(
+            f'<td style="padding: 8px; text-transform: uppercase;">'
+            f"{_escape(row.status)}</td>"
+        )
+        table.append(f'<td style="padding: 8px;">{_escape(row.detail)}</td>')
+        table.append("</tr>")
+    table.append("</table>")
+    table.append("<br>")
+    return "\n".join(table)
+
+
+def render_issues_html(issue_lines: list[str], source: str, limit: int = 40) -> str:
+    """Visually cleaned-up warnings/errors section (replaces raw pre dump)."""
+    if not issue_lines:
+        return (
+            "<h3>Warnings / Errors (24h)</h3>"
+            f"<p>None detected via { _escape(source) }.</p><br>"
+        )
+
+    shown = issue_lines[-limit:]
+    rows_html: list[str] = []
+    for line in shown:
+        level = "info"
+        upper = line.upper()
+        if "CRITICAL" in upper:
+            level = "critical"
+        elif "ERROR" in upper:
+            level = "error"
+        elif "WARN" in upper:
+            level = "warning"
+        style = _STATUS_STYLES.get(
+            {"critical": "error", "error": "error", "warning": "warn"}.get(level, "unknown"),
+            _STATUS_STYLES["unknown"],
+        )
+        rows_html.append(
+            f'<tr style="{style}">'
+            f'<td style="padding: 6px; white-space: nowrap;">{_escape(level)}</td>'
+            f'<td style="padding: 6px; font-family: monospace; font-size: 12px;">'
+            f"{_escape(line)}</td></tr>"
+        )
+
+    omitted = max(0, len(issue_lines) - len(shown))
+    note = ""
+    if omitted:
+        note = f"<p>Showing latest {len(shown)} of {len(issue_lines)} (source: {_escape(source)}).</p>"
+    else:
+        note = f"<p>Source: {_escape(source)}.</p>"
+
+    return (
+        "<h3>Warnings / Errors (24h)</h3>"
+        f"{note}"
+        '<table border="1" style="border-collapse: collapse; width: 100%;">'
+        '<tr style="background-color: #f2f2f2;">'
+        '<th style="padding: 6px; text-align: left;">Level</th>'
+        '<th style="padding: 6px; text-align: left;">Message</th>'
+        "</tr>"
+        + "".join(rows_html)
+        + "</table><br>"
+    )
+
+
+def _escape(text: str) -> str:
+    return (
+        str(text)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )

--- a/dailystatus/test_scorecard.py
+++ b/dailystatus/test_scorecard.py
@@ -1,0 +1,187 @@
+"""Tests for dailystatus Personal SRE scorecard (TJW-316)."""
+
+import datetime
+import unittest
+from unittest import mock
+
+from scorecard import (
+    ScorecardRow,
+    build_scorecard_rows,
+    check_pihole,
+    check_spotify,
+    check_ssl_expiry,
+    check_warnings_summary,
+    collect_log_issues,
+    parse_borg_archive_name,
+    parse_quality_updated_at,
+    parse_spotify_last_success,
+    rainbow_host_from_borg_path,
+    render_issues_html,
+    render_scorecard_html,
+)
+
+
+class ParseHelpersTests(unittest.TestCase):
+    def test_parse_borg_archive_name(self):
+        dt = parse_borg_archive_name("cloud-2026-08-10T03:05:37")
+        self.assertEqual(dt, datetime.datetime(2026, 8, 10, 3, 5, 37))
+        self.assertIsNone(parse_borg_archive_name("not-an-archive"))
+
+    def test_parse_quality_updated_at(self):
+        dt = parse_quality_updated_at("2026-08-10 19:00:02 PDT")
+        self.assertEqual(dt, datetime.datetime(2026, 8, 10, 19, 0, 2))
+        self.assertIsNone(parse_quality_updated_at(None))
+        self.assertIsNone(parse_quality_updated_at("bogus"))
+
+    def test_parse_spotify_last_success(self):
+        dt = parse_spotify_last_success("2026-08-10 19:20")
+        self.assertEqual(dt, datetime.datetime(2026, 8, 10, 19, 20))
+        self.assertIsNone(parse_spotify_last_success("nope"))
+
+    def test_rainbow_host_from_borg_path(self):
+        self.assertEqual(
+            rainbow_host_from_borg_path(
+                "ssh://tyler@38.102.87.250:22/~/syncthing-backups-borg-repo"
+            ),
+            "38.102.87.250",
+        )
+        self.assertIsNone(rainbow_host_from_borg_path("/local/path"))
+
+
+class CollectLogIssuesTests(unittest.TestCase):
+    def test_prefers_loki_when_configured(self):
+        cab = mock.Mock()
+        cab.logging_loki_url = "http://loki.example:3100"
+        cab.log_query_issues_loki.return_value = ["ERROR line"]
+        lines, source = collect_log_issues(cab)
+        self.assertEqual(source, "loki")
+        self.assertEqual(lines, ["ERROR line"])
+        cab.log_query_issues.assert_not_called()
+
+    def test_falls_back_to_local_when_loki_fails(self):
+        cab = mock.Mock()
+        cab.logging_loki_url = "http://loki.example:3100"
+        cab.log_query_issues_loki.side_effect = OSError("down")
+        cab.log_query_issues.return_value = ["WARN local"]
+        lines, source = collect_log_issues(cab)
+        self.assertEqual(source, "local")
+        self.assertEqual(lines, ["WARN local"])
+        # configured URL + localhost retry
+        self.assertGreaterEqual(cab.log_query_issues_loki.call_count, 2)
+
+    def test_unavailable_when_both_fail(self):
+        cab = mock.Mock()
+        cab.logging_loki_url = ""
+        cab.log_query_issues.side_effect = RuntimeError("boom")
+        lines, source = collect_log_issues(cab)
+        self.assertEqual(source, "unavailable")
+        self.assertEqual(lines, [])
+
+
+class CheckHelpersTests(unittest.TestCase):
+    def test_check_spotify_fresh(self):
+        now = datetime.datetime(2026, 8, 10, 20, 0)
+        cab = mock.Mock()
+        cab.get.return_value = {"last_success": "2026-08-10 19:20"}
+        row = check_spotify(cab, now)
+        self.assertEqual(row.status, "ok")
+
+    def test_check_spotify_stale(self):
+        now = datetime.datetime(2026, 8, 12, 20, 0)
+        cab = mock.Mock()
+        cab.get.return_value = {"last_success": "2026-08-10 19:20"}
+        row = check_spotify(cab, now)
+        self.assertEqual(row.status, "error")
+
+    def test_check_spotify_missing(self):
+        cab = mock.Mock()
+        cab.get.return_value = {}
+        row = check_spotify(cab, datetime.datetime(2026, 8, 10, 20, 0))
+        self.assertEqual(row.status, "unknown")
+        self.assertIn("unknown / not configured", row.detail)
+
+    def test_check_pihole_ok(self):
+        def run(cmd):
+            if cmd[:2] == ["docker", "ps"]:
+                return 0, "pihole Up 2 weeks (healthy)", ""
+            if "status" in cmd:
+                return 0, "  [✓] Pi-hole blocking is enabled", ""
+            return 1, "", "nope"
+
+        row = check_pihole(run_command=run)
+        self.assertEqual(row.status, "ok")
+        self.assertIn("blocking enabled", row.detail)
+
+    def test_check_pihole_docker_missing(self):
+        row = check_pihole(run_command=lambda _cmd: (127, "", "missing"))
+        self.assertEqual(row.status, "unknown")
+
+    def test_check_ssl_expiry_with_mock(self):
+        # Avoid real network: patch socket path by stubbing results via empty hosts
+        row = check_ssl_expiry(hosts=())
+        self.assertEqual(row.status, "unknown")
+
+    def test_warnings_summary(self):
+        row = check_warnings_summary(
+            ["2026 WARNING foo", "2026 ERROR bar"], "loki"
+        )
+        self.assertEqual(row.status, "error")
+        self.assertIn("1 error", row.detail)
+        self.assertIn("loki", row.detail)
+
+
+class RenderTests(unittest.TestCase):
+    def test_render_scorecard_html(self):
+        html = render_scorecard_html(
+            [ScorecardRow("Borg backups", "ok", "last success today")]
+        )
+        self.assertIn("Personal SRE Scorecard", html)
+        self.assertIn("Borg backups", html)
+        self.assertIn("OK", html.upper())
+
+    def test_render_issues_html_empty(self):
+        html = render_issues_html([], "loki")
+        self.assertIn("None detected", html)
+
+    def test_render_issues_html_escapes(self):
+        html = render_issues_html(["ERROR <script>alert(1)</script>"], "local")
+        self.assertIn("&lt;script&gt;", html)
+        self.assertNotIn("<script>", html)
+
+
+class BuildScorecardTests(unittest.TestCase):
+    def test_build_does_not_crash_on_missing_data(self):
+        cab = mock.Mock()
+        cab.get.side_effect = lambda *args, **kwargs: None
+        cab.logging_loki_url = ""
+        cab.log_query_issues.return_value = []
+
+        with mock.patch("scorecard._list_borg_archives", return_value=None):
+            with mock.patch("scorecard.check_ssl_expiry") as ssl_check:
+                ssl_check.return_value = ScorecardRow(
+                    "SSL expiry", "unknown", "unknown / not configured"
+                )
+                with mock.patch(
+                    "scorecard.check_pihole",
+                    return_value=ScorecardRow(
+                        "Pi-hole", "unknown", "unknown / not configured"
+                    ),
+                ):
+                    with mock.patch("scorecard.ping_host", return_value=False):
+                        rows, issues, source = build_scorecard_rows(
+                            cab,
+                            now=datetime.datetime(2026, 8, 10, 20, 0),
+                            quality_data={},
+                        )
+
+        self.assertTrue(rows)
+        self.assertEqual(source, "local")
+        self.assertEqual(issues, [])
+        # Every row should be a ScorecardRow with a known status token
+        for row in rows:
+            self.assertIn(row.status, {"ok", "warn", "error", "unknown"})
+            self.assertIsInstance(row.detail, str)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dailystatus/test_scorecard.py
+++ b/dailystatus/test_scorecard.py
@@ -9,7 +9,6 @@ from scorecard import (
     build_scorecard_rows,
     check_pihole,
     check_spotify,
-    check_ssl_expiry,
     check_warnings_summary,
     collect_log_issues,
     parse_borg_archive_name,
@@ -82,23 +81,32 @@ class CheckHelpersTests(unittest.TestCase):
     def test_check_spotify_fresh(self):
         now = datetime.datetime(2026, 8, 10, 20, 0)
         cab = mock.Mock()
-        cab.get.return_value = {"last_success": "2026-08-10 19:20"}
+        cab.get.return_value = {
+            "last_success": "2026-08-10 19:20",
+            "total_tracks": 6709,
+        }
         row = check_spotify(cab, now)
         self.assertEqual(row.status, "ok")
+        self.assertEqual(row.detail, "Checked 40m ago; 6709 songs.")
 
     def test_check_spotify_stale(self):
         now = datetime.datetime(2026, 8, 12, 20, 0)
         cab = mock.Mock()
-        cab.get.return_value = {"last_success": "2026-08-10 19:20"}
+        cab.get.return_value = {
+            "last_success": "2026-08-10 19:20",
+            "total_tracks": 6709,
+        }
         row = check_spotify(cab, now)
         self.assertEqual(row.status, "error")
+        self.assertIn("Checked", row.detail)
+        self.assertIn("6709 songs", row.detail)
 
     def test_check_spotify_missing(self):
         cab = mock.Mock()
         cab.get.return_value = {}
         row = check_spotify(cab, datetime.datetime(2026, 8, 10, 20, 0))
         self.assertEqual(row.status, "unknown")
-        self.assertIn("unknown / not configured", row.detail)
+        self.assertIn("song count unknown", row.detail)
 
     def test_check_pihole_ok(self):
         def run(cmd):
@@ -114,11 +122,6 @@ class CheckHelpersTests(unittest.TestCase):
 
     def test_check_pihole_docker_missing(self):
         row = check_pihole(run_command=lambda _cmd: (127, "", "missing"))
-        self.assertEqual(row.status, "unknown")
-
-    def test_check_ssl_expiry_with_mock(self):
-        # Avoid real network: patch socket path by stubbing results via empty hosts
-        row = check_ssl_expiry(hosts=())
         self.assertEqual(row.status, "unknown")
 
     def test_warnings_summary(self):
@@ -157,30 +160,48 @@ class BuildScorecardTests(unittest.TestCase):
         cab.log_query_issues.return_value = []
 
         with mock.patch("scorecard._list_borg_archives", return_value=None):
-            with mock.patch("scorecard.check_ssl_expiry") as ssl_check:
-                ssl_check.return_value = ScorecardRow(
-                    "SSL expiry", "unknown", "unknown / not configured"
-                )
-                with mock.patch(
-                    "scorecard.check_pihole",
-                    return_value=ScorecardRow(
-                        "Pi-hole", "unknown", "unknown / not configured"
-                    ),
-                ):
-                    with mock.patch("scorecard.ping_host", return_value=False):
-                        rows, issues, source = build_scorecard_rows(
-                            cab,
-                            now=datetime.datetime(2026, 8, 10, 20, 0),
-                            quality_data={},
-                        )
+            with mock.patch(
+                "scorecard.check_pihole",
+                return_value=ScorecardRow(
+                    "Pi-hole", "unknown", "unknown / not configured"
+                ),
+            ):
+                with mock.patch("scorecard.ping_host", return_value=False):
+                    rows, issues, source = build_scorecard_rows(
+                        cab,
+                        now=datetime.datetime(2026, 8, 10, 20, 0),
+                        quality_data={},
+                    )
 
         self.assertTrue(rows)
         self.assertEqual(source, "local")
         self.assertEqual(issues, [])
-        # Every row should be a ScorecardRow with a known status token
+        labels = {row.check for row in rows}
+        self.assertNotIn("Cloud drift", labels)
+        self.assertNotIn("Rainbow drift", labels)
+        self.assertNotIn("SSL expiry", labels)
         for row in rows:
             self.assertIn(row.status, {"ok", "warn", "error", "unknown"})
             self.assertIsInstance(row.detail, str)
+
+
+class CasualWeatherTests(unittest.TestCase):
+    def test_format_casual_tomorrow_weather(self):
+        # Import from main without running CLI
+        import main as dailystatus_main  # pylint: disable=import-outside-toplevel
+
+        line = dailystatus_main.format_casual_tomorrow_weather(
+            {
+                "tomorrow_high": 73,
+                "tomorrow_conditions": "Partly Cloudy",
+            }
+        )
+        self.assertEqual(line, "73 and partly cloudy tomorrow")
+
+    def test_format_casual_missing(self):
+        import main as dailystatus_main  # pylint: disable=import-outside-toplevel
+
+        self.assertIsNone(dailystatus_main.format_casual_tomorrow_weather({}))
 
 
 if __name__ == "__main__":

--- a/dailystatus/test_scorecard.py
+++ b/dailystatus/test_scorecard.py
@@ -1,4 +1,4 @@
-"""Tests for dailystatus Personal SRE scorecard (TJW-316)."""
+"""Tests for dailystatus Personal Metrics (TJW-316)."""
 
 import datetime
 import unittest
@@ -84,10 +84,13 @@ class CheckHelpersTests(unittest.TestCase):
         cab.get.return_value = {
             "last_success": "2026-08-10 19:20",
             "total_tracks": 6709,
+            "average_year": 2009.366515837104,
         }
         row = check_spotify(cab, now)
         self.assertEqual(row.status, "ok")
-        self.assertEqual(row.detail, "Checked 40m ago; 6709 songs.")
+        self.assertEqual(
+            row.detail, "Checked 40m ago; 6709 songs; avg year 2009."
+        )
 
     def test_check_spotify_stale(self):
         now = datetime.datetime(2026, 8, 12, 20, 0)
@@ -95,11 +98,13 @@ class CheckHelpersTests(unittest.TestCase):
         cab.get.return_value = {
             "last_success": "2026-08-10 19:20",
             "total_tracks": 6709,
+            "average_year": 2009.3,
         }
         row = check_spotify(cab, now)
         self.assertEqual(row.status, "error")
         self.assertIn("Checked", row.detail)
         self.assertIn("6709 songs", row.detail)
+        self.assertIn("avg year 2009", row.detail)
 
     def test_check_spotify_missing(self):
         cab = mock.Mock()
@@ -107,6 +112,7 @@ class CheckHelpersTests(unittest.TestCase):
         row = check_spotify(cab, datetime.datetime(2026, 8, 10, 20, 0))
         self.assertEqual(row.status, "unknown")
         self.assertIn("song count unknown", row.detail)
+        self.assertIn("avg year unknown", row.detail)
 
     def test_check_pihole_ok(self):
         def run(cmd):
@@ -130,7 +136,7 @@ class CheckHelpersTests(unittest.TestCase):
         )
         self.assertEqual(row.status, "error")
         self.assertIn("1 error", row.detail)
-        self.assertIn("loki", row.detail)
+        self.assertIn("(source: loki)", row.detail)
 
 
 class RenderTests(unittest.TestCase):
@@ -138,7 +144,7 @@ class RenderTests(unittest.TestCase):
         html = render_scorecard_html(
             [ScorecardRow("Borg backups", "ok", "last success today")]
         )
-        self.assertIn("Personal SRE Scorecard", html)
+        self.assertIn("Personal Metrics", html)
         self.assertIn("Borg backups", html)
         self.assertIn("OK", html.upper())
 
@@ -150,6 +156,19 @@ class RenderTests(unittest.TestCase):
         html = render_issues_html(["ERROR <script>alert(1)</script>"], "local")
         self.assertIn("&lt;script&gt;", html)
         self.assertNotIn("<script>", html)
+
+    def test_render_issues_links_loki_source(self):
+        html = render_issues_html(["WARNING something"], "loki")
+        self.assertIn("(source:", html)
+        self.assertIn("https://grafana.tyler.cloud/explore", html)
+        self.assertIn(">loki</a>", html)
+        # & in query string is HTML-escaped in the href attribute
+        self.assertIn("&amp;orgId=1", html)
+
+    def test_render_issues_local_source_not_linked(self):
+        html = render_issues_html(["WARNING something"], "local")
+        self.assertIn("(source: local)", html)
+        self.assertNotIn("<a href=", html)
 
 
 class BuildScorecardTests(unittest.TestCase):
@@ -196,7 +215,7 @@ class CasualWeatherTests(unittest.TestCase):
                 "tomorrow_conditions": "Partly Cloudy",
             }
         )
-        self.assertEqual(line, "73 and partly cloudy tomorrow")
+        self.assertEqual(line, "73° and partly cloudy tomorrow")
 
     def test_format_casual_missing(self):
         import main as dailystatus_main  # pylint: disable=import-outside-toplevel

--- a/dailystatus/test_scorecard.py
+++ b/dailystatus/test_scorecard.py
@@ -89,7 +89,8 @@ class CheckHelpersTests(unittest.TestCase):
         row = check_spotify(cab, now)
         self.assertEqual(row.status, "ok")
         self.assertEqual(
-            row.detail, "Checked 40m ago; 6709 songs; avg year 2009."
+            row.detail,
+            "Checked 40m ago; 6709 songs; avg year 2009.366515837104.",
         )
 
     def test_check_spotify_stale(self):
@@ -104,7 +105,7 @@ class CheckHelpersTests(unittest.TestCase):
         self.assertEqual(row.status, "error")
         self.assertIn("Checked", row.detail)
         self.assertIn("6709 songs", row.detail)
-        self.assertIn("avg year 2009", row.detail)
+        self.assertIn("avg year 2009.3", row.detail)
 
     def test_check_spotify_missing(self):
         cab = mock.Mock()


### PR DESCRIPTION
## Summary
- Adds a **Personal SRE Scorecard** section to every dailystatus email (Borg, cloud/rainbow drift, SSL expiry, disk, Pi-hole, Rainbow, Spotify freshness, warnings summary).
- Fixes warnings/errors collection for rainbow by preferring Cabinet Loki (`log_query_issues_loki`) with localhost + local-file fallbacks after Mongo log removal.
- Documents scorecard fields in `dailystatus/README.md` and adds unit tests.

## Test plan
- [ ] `cd ~/git/tools/dailystatus && python3 -m unittest test_scorecard test_foodlog_submit test_foodlog_goals`
- [ ] `python3 main.py --dry-run` on rainbow (or cloud) and confirm scorecard + cleaned warnings table render
- [ ] Confirm missing Cabinet/borg/docker data shows `unknown / not configured` without crashing
- [ ] After merge, verify next scheduled rainbow dailystatus email includes the scorecard