### PR TITLE
TJW-347: Show errors before warnings in the status email

### DIFF
--- a/dailystatus/README.md
+++ b/dailystatus/README.md
@@ -20,9 +20,9 @@ Fields (missing data → `unknown / not configured`, never crash the email):
 | Pi-hole | Local Docker `pihole` container + `pihole status` when available |
 | Rainbow | Ping host from `path.rainbow-borg`; `quality.rainbow.updated_at` as “last health check”; uptime when running on rainbow |
 | Spotify analytics | `Checked <age>; <n> songs; avg year <full decimal>.` from `spotipy` |
-| Warnings / errors (24h) | Prefer Cabinet **Loki**; when issues exist, `(source: loki)` links to Grafana Explore |
+| Errors / warnings (24h) | Prefer Cabinet **Loki**; when issues exist, `(source: loki)` links to Grafana Explore |
 
-The detailed warnings/errors section below the scorecard uses the same query, rendered as a compact level/message table.
+The detailed errors/warnings section below the scorecard uses the same query, rendered as a compact level/message table with errors first.
 
 ## dependencies
 - requests (`pip install requests`)

--- a/dailystatus/scorecard.py
+++ b/dailystatus/scorecard.py
@@ -446,7 +446,7 @@ def check_spotify(cab, now: datetime.datetime) -> ScorecardRow:
 def check_warnings_summary(issue_lines: list[str], source: str) -> ScorecardRow:
     if source == "unavailable":
         return ScorecardRow(
-            "Warnings / errors (24h)",
+            "Errors / warnings (24h)",
             "unknown",
             "unknown / not configured (log query failed)",
         )
@@ -466,7 +466,7 @@ def check_warnings_summary(issue_lines: list[str], source: str) -> ScorecardRow:
     else:
         status = "ok"
         detail = f"none (source: {source})"
-    return ScorecardRow("Warnings / errors (24h)", status, detail)
+    return ScorecardRow("Errors / warnings (24h)", status, detail)
 
 
 def build_scorecard_rows(
@@ -547,27 +547,72 @@ def _source_note_html(source: str, *, has_issues: bool) -> str:
     return f"(source: {_escape(source)})"
 
 
+def _issue_level(line: str) -> str:
+    """Classify a log line as critical, error, warning, or info."""
+    upper = line.upper()
+    if "CRITICAL" in upper:
+        return "critical"
+    if "ERROR" in upper:
+        return "error"
+    if "WARN" in upper:
+        return "warning"
+    return "info"
+
+
+def prioritize_issues_errors_first(
+    issue_lines: list[str], limit: int | None = None
+) -> list[str]:
+    """Return issues with critical/error before warnings; keep order within a level.
+
+    Source lines are chronological (oldest first). When ``limit`` truncates the
+    list, keep higher-severity items first and the latest entries within each
+    level so errors are not dropped in favor of newer warnings.
+    """
+    buckets: dict[str, list[str]] = {
+        "critical": [],
+        "error": [],
+        "warning": [],
+        "info": [],
+    }
+    for line in issue_lines:
+        buckets[_issue_level(line)].append(line)
+
+    if limit is None or len(issue_lines) <= limit:
+        return (
+            buckets["critical"]
+            + buckets["error"]
+            + buckets["warning"]
+            + buckets["info"]
+        )
+
+    shown: list[str] = []
+    remaining = limit
+    for key in ("critical", "error", "warning", "info"):
+        if remaining <= 0:
+            break
+        bucket = buckets[key]
+        take = bucket[-remaining:]
+        shown.extend(take)
+        remaining -= len(take)
+    return shown
+
+
 def render_issues_html(issue_lines: list[str], source: str, limit: int = 40) -> str:
-    """Visually cleaned-up warnings/errors section (replaces raw pre dump)."""
+    """Visually cleaned-up errors/warnings section (replaces raw pre dump)."""
     if not issue_lines:
         return (
-            "<h3>Warnings / Errors (24h)</h3>"
+            "<h3>Errors / Warnings (24h)</h3>"
             f"<p>None detected via {_escape(source)}.</p><br>"
         )
 
-    shown = issue_lines[-limit:]
+    shown = prioritize_issues_errors_first(issue_lines, limit)
     rows_html: list[str] = []
     for line in shown:
-        level = "info"
-        upper = line.upper()
-        if "CRITICAL" in upper:
-            level = "critical"
-        elif "ERROR" in upper:
-            level = "error"
-        elif "WARN" in upper:
-            level = "warning"
+        level = _issue_level(line)
         style = _STATUS_STYLES.get(
-            {"critical": "error", "error": "error", "warning": "warn"}.get(level, "unknown"),
+            {"critical": "error", "error": "error", "warning": "warn"}.get(
+                level, "unknown"
+            ),
             _STATUS_STYLES["unknown"],
         )
         rows_html.append(
@@ -581,14 +626,14 @@ def render_issues_html(issue_lines: list[str], source: str, limit: int = 40) -> 
     source_note = _source_note_html(source, has_issues=True)
     if omitted:
         note = (
-            f"<p>Showing latest {len(shown)} of {len(issue_lines)} "
-            f"{source_note}.</p>"
+            f"<p>Showing {len(shown)} of {len(issue_lines)} "
+            f"{source_note} (errors first).</p>"
         )
     else:
         note = f"<p>{source_note}.</p>"
 
     return (
-        "<h3>Warnings / Errors (24h)</h3>"
+        "<h3>Errors / Warnings (24h)</h3>"
         f"{note}"
         '<table border="1" style="border-collapse: collapse; width: 100%;">'
         '<tr style="background-color: #f2f2f2;">'

--- a/dailystatus/test_scorecard.py
+++ b/dailystatus/test_scorecard.py
@@ -14,6 +14,7 @@ from scorecard import (
     parse_borg_archive_name,
     parse_quality_updated_at,
     parse_spotify_last_success,
+    prioritize_issues_errors_first,
     rainbow_host_from_borg_path,
     render_issues_html,
     render_scorecard_html,
@@ -152,6 +153,7 @@ class RenderTests(unittest.TestCase):
     def test_render_issues_html_empty(self):
         html = render_issues_html([], "loki")
         self.assertIn("None detected", html)
+        self.assertIn("Errors / Warnings", html)
 
     def test_render_issues_html_escapes(self):
         html = render_issues_html(["ERROR <script>alert(1)</script>"], "local")
@@ -163,13 +165,35 @@ class RenderTests(unittest.TestCase):
         self.assertIn("(source:", html)
         self.assertIn("https://grafana.tyler.cloud/explore", html)
         self.assertIn(">loki</a>", html)
-        # & in query string is HTML-escaped in the href attribute
-        self.assertIn("&amp;orgId=1", html)
 
     def test_render_issues_local_source_not_linked(self):
         html = render_issues_html(["WARNING something"], "local")
         self.assertIn("(source: local)", html)
         self.assertNotIn("<a href=", html)
+
+    def test_render_issues_errors_before_warnings(self):
+        html = render_issues_html(
+            ["WARNING first", "ERROR second", "CRITICAL third", "WARNING fourth"],
+            "local",
+        )
+        error_pos = html.find("ERROR second")
+        critical_pos = html.find("CRITICAL third")
+        warn_first = html.find("WARNING first")
+        warn_fourth = html.find("WARNING fourth")
+        self.assertLess(critical_pos, error_pos)
+        self.assertLess(error_pos, warn_first)
+        self.assertLess(warn_first, warn_fourth)
+
+    def test_prioritize_keeps_latest_errors_when_over_limit(self):
+        lines = [f"WARNING w{i}" for i in range(30)] + [
+            "ERROR old",
+            "ERROR new",
+        ]
+        shown = prioritize_issues_errors_first(lines, limit=5)
+        self.assertEqual(shown[:2], ["ERROR old", "ERROR new"])
+        self.assertTrue(all("WARNING" in line for line in shown[2:]))
+        self.assertEqual(shown[-1], "WARNING w29")
+        self.assertEqual(len(shown), 5)
 
 
 class BuildScorecardTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Status email issues table now lists critical/error lines before warnings instead of mixed chronological order.
- When the 40-line cap applies, errors are kept first so they are not dropped in favor of newer warnings.
- Scorecard heading matches: Errors / warnings (24h).

## Test plan
- [ ] `cd dailystatus && python3 -m unittest test_scorecard.py`
- [ ] `python3 main.py --dry-run` and confirm the Errors / Warnings table lists errors above warnings
- [ ] If there are more than 40 issues, confirm errors still appear at the top