### PR TITLE
dailystatus: Classify issues by log level, not substring

### DIFF
--- a/dailystatus/main.py
+++ b/dailystatus/main.py
@@ -20,6 +20,7 @@ import cabinet
 from tyler_python_helpers import ChatGPT
 
 from scorecard import (
+    _issue_level,
     build_scorecard_rows,
     collect_log_issues,
     render_issues_html,
@@ -554,13 +555,15 @@ def analyze_logs(email, issue_lines=None, issue_source=None):
     if issue_lines is None or issue_source is None:
         issue_lines, issue_source = collect_log_issues(cab)
 
-    is_warnings = any("WARN" in issue for issue in issue_lines)
+    is_warnings = any(_issue_level(issue) == "warning" for issue in issue_lines)
     is_errors = any(
-        "ERROR" in issue or "CRITICAL" in issue for issue in issue_lines
+        _issue_level(issue) in ("error", "critical") for issue in issue_lines
     )
 
     error_lines = [
-        line for line in issue_lines if "ERROR" in line or "CRITICAL" in line
+        line
+        for line in issue_lines
+        if _issue_level(line) in ("error", "critical")
     ]
     only_food_log_error = len(error_lines) == 1 and any(
         "No food logged for today." in line for line in error_lines

--- a/dailystatus/scorecard.py
+++ b/dailystatus/scorecard.py
@@ -453,9 +453,9 @@ def check_warnings_summary(issue_lines: list[str], source: str) -> ScorecardRow:
     errors = [
         line
         for line in issue_lines
-        if "ERROR" in line.upper() or "CRITICAL" in line.upper()
+        if _issue_level(line) in ("error", "critical")
     ]
-    warnings = [line for line in issue_lines if "WARN" in line.upper()]
+    warnings = [line for line in issue_lines if _issue_level(line) == "warning"]
     detail = (
         f"{len(errors)} error(s), {len(warnings)} warning(s) (source: {source})"
     )
@@ -547,16 +547,37 @@ def _source_note_html(source: str, *, has_issues: bool) -> str:
     return f"(source: {_escape(source)})"
 
 
-def _issue_level(line: str) -> str:
-    """Classify a log line as critical, error, warning, or info."""
-    upper = line.upper()
-    if "CRITICAL" in upper:
-        return "critical"
-    if "ERROR" in upper:
-        return "error"
-    if "WARN" in upper:
+# Cabinet lines: ``2026-08-22 03:06:33,304 — WARNING -> path:8@host -> message``
+_CABINET_LEVEL_RE = re.compile(
+    r" — (?P<level>CRITICAL|ERROR|WARNING|WARN|INFO|DEBUG)(?: \[|->)",
+    re.IGNORECASE,
+)
+# Unstructured fixtures / non-Cabinet lines: whole-word only so ``borg-errors`` is not ERROR.
+_FALLBACK_LEVEL_RE = re.compile(
+    r"\b(?P<level>CRITICAL|ERROR|WARNING|WARN)\b",
+    re.IGNORECASE,
+)
+
+
+def _normalize_issue_level(raw: str) -> str:
+    low = raw.lower()
+    if low == "warn":
         return "warning"
-    return "info"
+    if low == "debug":
+        return "info"
+    return low
+
+
+def _issue_level(line: str) -> str:
+    """Classify a log line as critical, error, warning, or info.
+
+    Prefer the Cabinet level field (`` — WARNING -> ``) so a WARNING whose
+    message mentions ``borg-errors`` or ``error.log`` is not treated as ERROR.
+    """
+    match = _CABINET_LEVEL_RE.search(line) or _FALLBACK_LEVEL_RE.search(line)
+    if not match:
+        return "info"
+    return _normalize_issue_level(match.group("level"))
 
 
 def prioritize_issues_errors_first(

--- a/dailystatus/test_scorecard.py
+++ b/dailystatus/test_scorecard.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 from scorecard import (
     ScorecardRow,
+    _issue_level,
     build_scorecard_rows,
     check_pihole,
     check_spotify,
@@ -140,6 +141,18 @@ class CheckHelpersTests(unittest.TestCase):
         self.assertIn("1 error", row.detail)
         self.assertIn("(source: loki)", row.detail)
 
+    def test_warnings_summary_ignores_error_substring_in_path(self):
+        line = (
+            "2026-08-22 03:06:33,304 — WARNING -> bin/cabinet:8@cloud -> "
+            "Full Borg transcript: /home/tyler/.cabinet/log/borg-errors/"
+            "borg-warning-20260822-030633.log"
+        )
+        row = check_warnings_summary([line], "loki")
+        self.assertEqual(row.status, "warn")
+        self.assertIn("0 error", row.detail)
+        self.assertIn("1 warning", row.detail)
+        self.assertEqual(_issue_level(line), "warning")
+
 
 class RenderTests(unittest.TestCase):
     def test_render_scorecard_html(self):
@@ -195,6 +208,16 @@ class RenderTests(unittest.TestCase):
         self.assertEqual(shown[-1], "WARNING w29")
         self.assertEqual(len(shown), 5)
 
+    def test_render_issues_uses_cabinet_level_not_message(self):
+        warning = (
+            "2026-08-22 03:06:33,304 — WARNING -> bin/cabinet:8@cloud -> "
+            "Full Borg transcript: /home/tyler/.cabinet/log/borg-errors/"
+            "borg-warning-20260822-030633.log"
+        )
+        html = render_issues_html([warning], "local")
+        self.assertIn(">warning</td>", html)
+        self.assertNotIn(">error</td>", html)
+
 
 class BuildScorecardTests(unittest.TestCase):
     def test_build_does_not_crash_on_missing_data(self):
@@ -246,6 +269,23 @@ class CasualWeatherTests(unittest.TestCase):
         import main as dailystatus_main  # pylint: disable=import-outside-toplevel
 
         self.assertIsNone(dailystatus_main.format_casual_tomorrow_weather({}))
+
+
+class AnalyzeLogsTests(unittest.TestCase):
+    def test_does_not_treat_borg_errors_path_as_error(self):
+        import main as dailystatus_main  # pylint: disable=import-outside-toplevel
+
+        line = (
+            "2026-08-22 03:06:33,304 — WARNING -> bin/cabinet:8@cloud -> "
+            "Full Borg transcript: /home/tyler/.cabinet/log/borg-errors/"
+            "borg-warning-20260822-030633.log"
+        )
+        _, is_warnings, is_errors, only_food = dailystatus_main.analyze_logs(
+            "", issue_lines=[line], issue_source="loki"
+        )
+        self.assertTrue(is_warnings)
+        self.assertFalse(is_errors)
+        self.assertFalse(only_food)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Status email issue classification now reads the Cabinet ` — LEVEL -> ` field instead of scanning the whole line for `ERROR` / `WARN`.
- A WARNING whose message mentions `borg-errors` is no longer counted as an error (scorecard, issues table, and subject line).

## Test plan
- [ ] `cd dailystatus && python3 -m unittest test_scorecard.py`
- [ ] Confirm a line like `— WARNING -> ... borg-errors/borg-warning-....log` shows as warning, not error