### PR TITLE
TJW-351: Stop backing up and health-checking Affine

### DIFF
--- a/borg/README.md
+++ b/borg/README.md
@@ -60,7 +60,7 @@ See **[docs/archive-contents.md](docs/archive-contents.md)** for the full invent
 
 Summary:
 
-- `$HOME/syncthing`, `$HOME/git` (no `.git`), `$HOME/.config`, `$HOME/.zshrc`, `$HOME/.affine`
+- `$HOME/syncthing`, `$HOME/git` (no `.git`), `$HOME/.config`, `$HOME/.zshrc`
 - Staged per run: crontab, `/etc/cloudflared`, `/root/.config/rustdesk`
 - Pre-export DB/config snapshots under `~/git/docker/*/database-backup`, `taiga-backup`, `pihole-backup`
 - Compression: LZ4; exclusions for live DB trees and caches — details in `main.sh` and docs

--- a/borg/docs/archive-contents.md
+++ b/borg/docs/archive-contents.md
@@ -10,7 +10,6 @@ Source: `~/git/tools/borg/main.sh`. Archives use compression `lz4`.
 | `$HOME/git` | Docker stacks, dotfiles, tools (**`.git` dirs excluded**) |
 | `$HOME/.zshrc` | Shell config |
 | `$HOME/.config` | Includes `rustdesk/`, app configs |
-| `$HOME/.affine` | Affine local data |
 | Temp dir (see below) | Crontab + staged root-only configs |
 
 ## Staged inside temp directory (per backup run)
@@ -32,7 +31,6 @@ Created immediately before `borg create`, then deleted after backup. They **are*
 | Stack | Export path | Live data excluded from Borg |
 |-------|-------------|------------------------------|
 | Immich | `docker/immich/database-backup/immich-database.sql` | `docker/immich/postgres/` |
-| Affine | `docker/affine/database-backup/affine-database.sql` | postgres data dir |
 | Authentik | `docker/authentik/database-backup/authentik-database.sql` | `postgresql/`, `redis/` |
 | Miniflux | `docker/miniflux/database-backup/miniflux-database.sql` | postgres data dir |
 | Taiga | `docker/taiga-docker/taiga-backup/taiga_db.sql`, `media/`, `static/` | named volumes |

--- a/borg/docs/restore-order.md
+++ b/borg/docs/restore-order.md
@@ -14,7 +14,7 @@ Dependencies matter: tunnels, databases, and auth before apps that rely on them.
 1. Restore `$HOME/git` (Docker stacks, dotfiles, tools).
 2. Restore `$HOME/syncthing`.
 3. Restore `$HOME/.config` (includes RustDesk client config).
-4. Restore `$HOME/.zshrc`, `$HOME/.affine` if present.
+4. Restore `$HOME/.zshrc`.
 5. Install dotfiles / run ansible if you use `~/git/dotfiles/scripts/setup.sh` (optional; after tree is in place).
 
 ## Phase 2 — Host-level secrets and scheduling
@@ -30,7 +30,7 @@ Dependencies matter: tunnels, databases, and auth before apps that rely on them.
 2. Start **databases and auth** before apps that depend on them:
    - MongoDB (if apps need it)
    - Authentik
-   - Postgres-backed stacks (Immich, Affine, Miniflux, Taiga, Dawarich)
+   - Postgres-backed stacks (Immich, Miniflux, Taiga, Dawarich)
 3. Restore DB **from snapshots** before or right after first container start — see [services.md](services.md).
 
 ## Phase 4 — Application stacks
@@ -39,7 +39,7 @@ Start order (loose; adjust per stack README):
 
 1. Pi-hole (if on this host)
 2. Gitea / git hosting
-3. Immich, Affine, media stacks
+3. Immich, media stacks
 4. RustDesk (`docker compose up -d` in `~/git/docker/rustdesk`)
 5. RustDesk **client** systemd service: `sudo systemctl enable --now rustdesk`
 6. Remaining compose projects (Loki, Kuma, Vaultwarden, Taiga, sure.am, …)

--- a/borg/docs/services.md
+++ b/borg/docs/services.md
@@ -61,14 +61,6 @@ Photo library paths are in `.env` (`UPLOAD_LOCATION`); ensure bind mounts exist.
 
 ---
 
-## Affine
-
-| Export | `affine/database-backup/affine-database.sql` |
-
-Import into `affine_postgres` after DB container is up. Custom image build documented in `affine/README.md`.
-
----
-
 ## Authentik
 
 | Export | `authentik/database-backup/authentik-database.sql` |

--- a/borg/main.sh
+++ b/borg/main.sh
@@ -184,7 +184,6 @@ else
         add_backup_path "$HOME/git"
         add_backup_path "$HOME/.zshrc"
         add_backup_path "$HOME/.config"
-        add_backup_path "$HOME/.affine"
 
         # Cloudflared (systemd e.g. cloudflared-setup/cloudflared@*.service): tunnel JSON + cert.pem
         # live under /etc/cloudflared and are usually root-readable only. Stage into the same temp
@@ -255,22 +254,6 @@ else
                 fi
             else
                 debug "Immich postgres not running, skipping database dump"
-            fi
-        fi
-
-        # Export Affine database for backup (pg_dump - postgres data dir has restrictive perms)
-        AFFINE_DIR="$HOME/git/docker/affine"
-        AFFINE_BACKUP_DIR="$AFFINE_DIR/database-backup"
-        if [ -d "$AFFINE_DIR" ] && command -v docker >/dev/null 2>&1; then
-            mkdir -p "$AFFINE_BACKUP_DIR"
-            if docker ps --format '{{.Names}}' 2>/dev/null | grep -q affine_postgres; then
-                if docker exec -t affine_postgres pg_dump -U affine affine > "$AFFINE_BACKUP_DIR/affine-database.sql" 2>/dev/null; then
-                    debug "Affine database dumped to database-backup/"
-                else
-                    warning "Failed to dump Affine database"
-                fi
-            else
-                debug "Affine postgres not running, skipping database dump"
             fi
         fi
 

--- a/quality/service_check.py
+++ b/quality/service_check.py
@@ -172,7 +172,7 @@ def main():
         cabinet.log(f"✗ Syncthing base directory missing: {syncthing_base}", level="error")
 
     # Ping external hosts
-    external_hosts = ["git.tyler.cloud", "photos.tyler.cloud", "affine.tyler.cloud"]
+    external_hosts = ["git.tyler.cloud", "photos.tyler.cloud"]
 
     for host in external_hosts:
         if ping_host(host):


### PR DESCRIPTION
## Summary
- Drop Affine from Borg backup paths/docs and `service_check` pings; the self-hosted stack is gone.

## Test plan
- [x] Affine containers, `~/.affine`, `cloudflared@affine`, and `affine.tyler.cloud` DNS are removed on the homelab host
- [ ] Next Borg run does not look for `affine_postgres` or `$HOME/.affine`