### PR TITLE
TJW-334: Don't AI-correct tracks already in one genre playlist

### DIFF
--- a/spotify_analytics/README.md
+++ b/spotify_analytics/README.md
@@ -3,9 +3,12 @@ Checks for duplicate songs, unplayable songs (US market via Spotify `is_playable
 track relinking), and songs missing from playlists.
 
 Local files:
-- Genres are classified with ChatGPT (OpenAI), same as catalog tracks — not hard-defaulted to Pop.
-- Spotify Web API cannot add/move `spotify:local:` URIs; rule breaks (e.g. in Tyler Radio
-  but missing from the genre playlist) are **flagged only**, not auto-fixed via catalog search.
+- ChatGPT (OpenAI) is used for genre **only when a track is not already in a genre
+  playlist**. If it is in exactly one genre playlist, that is fine regardless of which
+  genre (AI never reassigns). Membership matching uses local URI when available, then
+  title+artist+album, with a title fallback when artist/album metadata is missing.
+- Spotify Web API cannot add/move `spotify:local:` URIs; if a local track is in Tyler
+  Radio but **no** genre playlist, that gap is flagged only (no catalog substitute).
 - Duplicate detection: catalog tracks by Spotify URL/ID; local files by title + artist + album.
 
 Unplayable detection:

--- a/spotify_analytics/main.py
+++ b/spotify_analytics/main.py
@@ -49,6 +49,7 @@ class Track:
     genre: Optional[str] = None
     is_local: bool = False
     album: str = ""
+    local_uri: str = ""  # spotify:local:... when is_local
 
     @classmethod
     def from_spotify_track(
@@ -75,6 +76,7 @@ class Track:
             genre=genre,
             is_local=is_local,
             album=album.get("name") or "",
+            local_uri=(track.get("uri") or "") if is_local else "",
         )
 
 
@@ -974,11 +976,19 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         self.cab.log(message, level=level, log_folder_path=log_folder_path, log_name=log_name)
 
     def _validate_and_retry_genres(self):
-        """Validate that all tracks have valid genres and retry classification for missing ones."""
+        """Validate genres; ChatGPT only for tracks not already in a genre playlist."""
         tracks_missing_genre = []
         tracks_invalid_genre = []
 
         for track in self.main_tracks:
+            membership = self._find_genre_playlists_for_track(track)
+            if membership:
+                # Already categorized in Spotify — do not ask AI to "correct" it
+                if len(membership) == 1 and membership[0] in self.VALID_GENRES:
+                    track.genre = membership[0]
+                    self._genre_cache[self._genre_cache_key(track)] = membership[0]
+                continue
+
             if not track.genre:
                 tracks_missing_genre.append(track)
             elif track.genre not in self.VALID_GENRES:
@@ -988,7 +998,7 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         if tracks_missing_genre:
             self.cab.log(
                 f"SPOTIFY - Found {len(tracks_missing_genre)} tracks missing "
-                f"genre, retrying classification",
+                f"genre (not in any genre playlist), classifying with ChatGPT",
                 level="info",
             )
 
@@ -1010,7 +1020,7 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
                 tracks_needing_api_call, "missing genres", "info"
             )
 
-        # Process invalid genres
+        # Process invalid genres (only when not already in a genre playlist)
         if tracks_invalid_genre:
             self.cab.log(
                 f"SPOTIFY - Found {len(tracks_invalid_genre)} tracks with "
@@ -1024,6 +1034,10 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         # Final validation
         still_missing = [
             t for t in self.main_tracks if not t.genre or t.genre not in self.VALID_GENRES
+        ]
+        # Tracks in multiple genre playlists may intentionally lack a single genre
+        still_missing = [
+            t for t in still_missing if not self._find_genre_playlists_for_track(t)
         ]
         if still_missing:
             track_list = ", ".join([f"'{t.name}' by {t.artist}" for t in still_missing[:5]])
@@ -1096,10 +1110,17 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
                 )
             )
 
-        # Process all pending classifications (batch across all pages)
+        # Prefer genre-playlist membership over cached/AI genres, then classify
+        # only tracks that are not already in a genre playlist.
+        self._assign_genres_from_playlists()
+        self._pending_classifications = [
+            (track_obj, key)
+            for track_obj, key in self._pending_classifications
+            if not track_obj.genre or track_obj.genre not in self.VALID_GENRES
+        ]
         self._process_pending_classifications()
 
-        # Validate and retry genres for all tracks
+        # Validate and retry genres for tracks still missing a genre
         self._validate_and_retry_genres()
 
         unplayable_count = len(self._unplayable_tracks)
@@ -1278,6 +1299,7 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
                     genre=track_dict.get("genre"),
                     is_local=bool(is_local),
                     album=track_dict.get("album", "") or "",
+                    local_uri=track_dict.get("local_uri", "") or "",
                 )
                 self.main_tracks.append(track)
 
@@ -1323,15 +1345,96 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         if len(self.playlist_data) > 8:
             self._check_playlist_exclusion(self.playlist_data[8], self.playlist_data[0])
 
+    def _local_ref_matches_track(self, track: Track, ref: PlaylistTrackRef) -> bool:
+        """True if a local playlist ref is the same song as track.
+
+        Prefer URI, then title+artist+album. If artist/album is missing on either
+        side (common for locals), fall back to title match with compatible artist.
+        """
+        if not ref.is_local:
+            return False
+        if track.local_uri and ref.key and track.local_uri == ref.key:
+            return True
+        if self._local_identity(track.name, track.artist, track.album) == self._local_identity(
+            ref.name, ref.artist, ref.album
+        ):
+            return True
+
+        title = self._normalize_field(track.name)
+        if not title or title != self._normalize_field(ref.name):
+            return False
+
+        track_artist = self._normalize_field(track.artist)
+        ref_artist = self._normalize_field(ref.artist)
+        if track_artist and ref_artist and track_artist != ref_artist:
+            return False
+
+        track_album = self._normalize_field(track.album)
+        ref_album = self._normalize_field(ref.album)
+        if track_album and ref_album and track_album != ref_album:
+            return False
+
+        return True
+
     def _local_ref_in_playlist(self, track: Track, playlist: PlaylistData) -> bool:
-        """True if playlist has a local entry matching title+artist+album."""
-        identity = self._local_identity(track.name, track.artist, track.album)
+        """True if playlist has a local entry matching this track."""
+        if track.local_uri and track.local_uri in playlist.tracks:
+            return True
         for ref in playlist.track_refs:
-            if not ref.is_local:
-                continue
-            if self._local_identity(ref.name, ref.artist, ref.album) == identity:
+            if self._local_ref_matches_track(track, ref):
                 return True
         return False
+
+    def _genre_playlists(self) -> List[PlaylistData]:
+        """Configured genre playlists (indices 2–7), or empty if not loaded."""
+        if len(self.playlist_data) < 8:
+            return []
+        return self.playlist_data[2:8]
+
+    def _find_genre_playlists_for_track(self, track: Track) -> List[str]:
+        """Genre playlist names that already contain this track.
+
+        Exactly one membership means the track is categorized (any genre is fine).
+        """
+        names: List[str] = []
+        for playlist in self._genre_playlists():
+            if track.is_local or not track.spotify_url:
+                if self._local_ref_in_playlist(track, playlist):
+                    names.append(playlist.name)
+            elif track.spotify_url in playlist.tracks:
+                names.append(playlist.name)
+        return names
+
+    def _assign_genres_from_playlists(self) -> None:
+        """Set genre from existing genre-playlist membership (beats ChatGPT/cache).
+
+        ChatGPT is only for tracks that are not in any genre playlist yet.
+        """
+        assigned = 0
+        for track in self.main_tracks:
+            membership = self._find_genre_playlists_for_track(track)
+            if len(membership) == 1 and membership[0] in self.VALID_GENRES:
+                genre = membership[0]
+                if track.genre != genre:
+                    self.cab.log(
+                        f"SPOTIFY - Using playlist genre '{genre}' for "
+                        f"'{track.name}' by {track.artist} "
+                        f"(was '{track.genre or 'unset'}')",
+                        level="debug",
+                    )
+                track.genre = genre
+                self._genre_cache[self._genre_cache_key(track)] = genre
+                assigned += 1
+            elif len(membership) > 1:
+                # Ambiguous membership — do not let AI pick a "correct" genre
+                if track.genre not in membership:
+                    track.genre = None
+        if assigned:
+            self.cab.log(
+                f"SPOTIFY - Assigned genre from playlist membership for "
+                f"{assigned} track(s)",
+                level="info",
+            )
 
     def _check_local_duplicates_across_playlists(self):
         """Flag local files that share title+artist+album across genre playlists."""
@@ -1432,11 +1535,12 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
             return False
 
     def _validate_genre_assignments(self):
-        """Verify that each Tyler Radio track appears in exactly one genre playlist.
+        """Ensure Tyler Radio tracks that lack a genre playlist get one.
 
-        Catalog tracks are added/removed via the API by URL.
-        Local files cannot be moved via the API — rule breaks are flagged only.
-        Genres themselves come from ChatGPT (OpenAI), not Spotify.
+        If a track is already in any genre playlist, that membership is final —
+        never compare against an AI genre or warn/move it to a different one.
+        ChatGPT genres are only used when the track is in no genre playlist yet
+        (catalog: add via API; local: flag only).
         """
         if len(self.playlist_data) < 8:
             self.cab.log(
@@ -1451,14 +1555,16 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
         for playlist in genre_playlists:
             genre_to_playlist[playlist.name] = playlist
 
-        # Catalog: URL -> list of genre playlist names
-        track_playlist_map: Dict[str, List[str]] = {}
-        for playlist in genre_playlists:
-            for track_url in playlist.tracks:
-                if self._extract_track_id(track_url):
-                    track_playlist_map.setdefault(track_url, []).append(playlist.name)
-
         for track in self.main_tracks:
+            membership = self._find_genre_playlists_for_track(track)
+            if membership:
+                # Already categorized — trust Spotify playlists, never AI-correct
+                if len(membership) == 1 and membership[0] in self.VALID_GENRES:
+                    track.genre = membership[0]
+                    self._genre_cache[self._genre_cache_key(track)] = membership[0]
+                continue
+
+            # Not in any genre playlist — need an AI/cache genre to place or flag
             if not track.genre or track.genre not in self.VALID_GENRES:
                 continue
 
@@ -1470,90 +1576,44 @@ IMPORTANT: The array size must exactly match the number of songs provided or the
                 )
                 continue
 
-            # Local files: flag rule breaks; do not search/add catalog substitutes
+            # Local files: flag only (API cannot add local URIs)
             if track.is_local or not track.spotify_url:
-                in_correct = self._local_ref_in_playlist(track, expected_playlist)
-                wrong = [
-                    playlist.name
-                    for playlist in genre_playlists
-                    if playlist.name != track.genre
-                    and self._local_ref_in_playlist(track, playlist)
-                ]
                 label = f"'{track.name}' by {track.artist} [{track.album}]"
-                if not in_correct:
-                    self.cab.log(
-                        f"SPOTIFY - Local file {label} is in Tyler Radio but missing "
-                        f"from '{track.genre}' playlist (cannot add local via API)",
-                        level="warning",
-                    )
-                for wrong_name in wrong:
-                    self.cab.log(
-                        f"SPOTIFY - Local file {label} is in '{wrong_name}' playlist "
-                        f"(should be in '{track.genre}') (cannot move local via API)",
-                        level="warning",
-                    )
+                self.cab.log(
+                    f"SPOTIFY - Local file {label} is in Tyler Radio but missing "
+                    f"from '{track.genre}' playlist (cannot add local via API)",
+                    level="warning",
+                )
                 continue
 
             track_url = track.spotify_url
-            is_in_correct_playlist = track_url in expected_playlist.tracks
-            wrong_playlists = [
-                name
-                for name in track_playlist_map.get(track_url, [])
-                if name != track.genre
-            ]
+            if track_url in expected_playlist.tracks:
+                continue
 
-            if not is_in_correct_playlist:
+            self.cab.log(
+                f"SPOTIFY - Adding track {track_url} to '{track.genre}' playlist",
+                level="info",
+            )
+            success = self._add_track_to_playlist(
+                expected_playlist.playlist_id, track_url, track.genre
+            )
+            if success:
+                expected_playlist.tracks.append(track_url)
+                expected_playlist.track_refs.append(
+                    PlaylistTrackRef(
+                        key=track_url,
+                        name=track.name,
+                        artist=track.artist,
+                        album=track.album,
+                        is_local=False,
+                    )
+                )
+            else:
                 self.cab.log(
-                    f"SPOTIFY - Adding track {track_url} to '{track.genre}' playlist",
-                    level="info",
+                    f"SPOTIFY - Warning: Could not add track {track_url} "
+                    f"to '{track.genre}' playlist",
+                    level="warning",
                 )
-                success = self._add_track_to_playlist(
-                    expected_playlist.playlist_id, track_url, track.genre
-                )
-                if success:
-                    expected_playlist.tracks.append(track_url)
-                    expected_playlist.track_refs.append(
-                        PlaylistTrackRef(
-                            key=track_url,
-                            name=track.name,
-                            artist=track.artist,
-                            album=track.album,
-                            is_local=False,
-                        )
-                    )
-                else:
-                    self.cab.log(
-                        f"SPOTIFY - Warning: Could not add track {track_url} "
-                        f"to '{track.genre}' playlist",
-                        level="warning",
-                    )
-
-            for wrong_playlist_name in wrong_playlists:
-                wrong_playlist = genre_to_playlist.get(wrong_playlist_name)
-                if wrong_playlist and wrong_playlist.playlist_id:
-                    self.cab.log(
-                        f"SPOTIFY - Removing track {track_url} from "
-                        f"'{wrong_playlist_name}' playlist (should be in "
-                        f"'{track.genre}')",
-                        level="info",
-                    )
-                    success = self._remove_track_from_playlist(
-                        wrong_playlist.playlist_id, track_url, wrong_playlist_name
-                    )
-                    if success:
-                        if track_url in wrong_playlist.tracks:
-                            wrong_playlist.tracks.remove(track_url)
-                        wrong_playlist.track_refs = [
-                            ref
-                            for ref in wrong_playlist.track_refs
-                            if ref.key != track_url
-                        ]
-                    else:
-                        self.cab.log(
-                            f"SPOTIFY - Warning: Could not remove track "
-                            f"{track_url} from '{wrong_playlist_name}' playlist",
-                            level="warning",
-                        )
 
     def _check_playlist_subset(self, subset: PlaylistData, superset: PlaylistData):
         """Verify that all tracks in subset appear in superset.

--- a/spotify_analytics/test_local_matching.py
+++ b/spotify_analytics/test_local_matching.py
@@ -1,9 +1,19 @@
 #!/usr/bin/env python3
-"""Unit tests for local duplicate identity (TJW-334)."""
+"""Unit tests for local duplicate identity and genre membership (TJW-334)."""
 
 import unittest
 
-from main import SpotifyAnalyzer
+from main import PlaylistData, PlaylistTrackRef, SpotifyAnalyzer, Track
+
+
+class FakeCab:
+    """Capture Cabinet log messages."""
+
+    def __init__(self):
+        self.msgs = []
+
+    def log(self, msg, level="info", **_kwargs):
+        self.msgs.append((level, msg))
 
 
 class TestLocalMatching(unittest.TestCase):
@@ -45,6 +55,131 @@ class TestLocalMatching(unittest.TestCase):
         )
         self.assertIsNone(
             self.analyzer._extract_track_id("spotify:local:Nena::99+Red+Balloons:230")
+        )
+
+
+class TestGenreAssignmentNoPolicing(unittest.TestCase):
+    """Exactly one genre playlist is enough; AI must not reassign."""
+
+    def setUp(self):
+        self.analyzer = object.__new__(SpotifyAnalyzer)
+        self.analyzer._genre_cache = {}
+        self.analyzer.cab = FakeCab()
+        self.analyzer.VALID_GENRES = SpotifyAnalyzer.VALID_GENRES
+        self.analyzer.playlist_data = [
+            PlaylistData("Tyler Radio", [], None, []),
+            PlaylistData("Last 25", [], None, []),
+            PlaylistData("Chill and Lofi", [], "c", []),
+            PlaylistData("Hip-Hop and Rap", [], "h", []),
+            PlaylistData("Party and EDM", [], "p", []),
+            PlaylistData("Pop", [], "o", []),
+            PlaylistData("R&B", [], "r", []),
+            PlaylistData("Rock", [], "k", []),
+        ]
+
+    def test_cookie_cutter_in_rnb_not_moved_to_ai_genre(self):
+        track = Track(
+            1,
+            "Quasian",
+            "Cookie Cutter",
+            "",
+            "",
+            genre="Hip-Hop and Rap",
+            is_local=True,
+            album="[standalone recordings]",
+        )
+        self.analyzer.main_tracks = [track]
+        self.analyzer.playlist_data[6] = PlaylistData(
+            "R&B",
+            [],
+            "r",
+            [
+                PlaylistTrackRef(
+                    "spotify:local:Quasian:[standalone recordings]:Cookie+Cutter:180",
+                    "Cookie Cutter",
+                    "Quasian",
+                    "[standalone recordings]",
+                    True,
+                )
+            ],
+        )
+
+        self.analyzer._validate_genre_assignments()
+
+        self.assertEqual(track.genre, "R&B")
+        joined = " ".join(msg for _, msg in self.analyzer.cab.msgs)
+        self.assertNotIn("should be in", joined)
+        self.assertNotIn("missing from", joined)
+
+    def test_sparse_metadata_still_counts_as_one_genre(self):
+        track = Track(
+            1,
+            "",
+            "Cookie Cutter",
+            "",
+            "",
+            genre="Chill and Lofi",
+            is_local=True,
+            album="",
+            local_uri="spotify:local:::Cookie+Cutter:180",
+        )
+        self.analyzer.main_tracks = [track]
+        self.analyzer.playlist_data[6] = PlaylistData(
+            "R&B",
+            [],
+            "r",
+            [PlaylistTrackRef("spotify:local:x", "Cookie Cutter", "Quasian", "Alb", True)],
+        )
+
+        self.assertEqual(self.analyzer._find_genre_playlists_for_track(track), ["R&B"])
+        self.analyzer._validate_genre_assignments()
+        self.assertEqual(track.genre, "R&B")
+        self.assertFalse(
+            any("should be in" in msg or "missing from" in msg for _, msg in self.analyzer.cab.msgs)
+        )
+
+    def test_catalog_already_in_one_genre_is_not_moved(self):
+        url = "https://open.spotify.com/track/abc123abc123abc123abc1"
+        track = Track(
+            1,
+            "Artist",
+            "Song",
+            "",
+            url,
+            genre="Rock",
+            is_local=False,
+            album="Album",
+        )
+        self.analyzer.main_tracks = [track]
+        self.analyzer.playlist_data[5] = PlaylistData("Pop", [url], "o", [])
+
+        self.analyzer._validate_genre_assignments()
+
+        self.assertEqual(track.genre, "Pop")
+        self.assertEqual(self.analyzer.playlist_data[5].tracks, [url])
+        self.assertEqual(self.analyzer.playlist_data[7].tracks, [])
+        joined = " ".join(msg for _, msg in self.analyzer.cab.msgs)
+        self.assertNotIn("Adding track", joined)
+        self.assertNotIn("Removing track", joined)
+        self.assertNotIn("should be in", joined)
+
+    def test_local_missing_all_genre_playlists_is_flagged(self):
+        track = Track(
+            1,
+            "Quasian",
+            "Cookie Cutter",
+            "",
+            "",
+            genre="Hip-Hop and Rap",
+            is_local=True,
+            album="[standalone recordings]",
+        )
+        self.analyzer.main_tracks = [track]
+
+        self.analyzer._validate_genre_assignments()
+
+        self.assertTrue(
+            any("missing from 'Hip-Hop and Rap'" in msg for _, msg in self.analyzer.cab.msgs)
         )
 
 


### PR DESCRIPTION
## Summary
- Genre validation no longer treats ChatGPT's label as the "correct" playlist. If a track is already in **exactly one** genre playlist, that membership wins (Cookie Cutter in R&B stays R&B even if AI says Hip-Hop).
- ChatGPT is used only when a Tyler Radio track is in **no** genre playlist yet (catalog: add via API; local: flag only).
- Restores the Aug 9 anti-policing logic that was committed on `fix/TJW-334-local-song-genre-duplicates` after that PR had already merged, so it never reached `main`.

## Test plan
- [ ] `python3 -m unittest test_local_matching.py` in `spotify_analytics/`
- [ ] Confirm Cookie Cutter (local, in R&B) no longer logs `should be in 'Hip-Hop and Rap'`
- [ ] Confirm a local in Tyler Radio with **zero** genre playlists still warns that it is missing
- [ ] Confirm a catalog track already in one genre playlist is not added/removed to match AI


Made with [Cursor](https://cursor.com)