### PR TITLE
TJW-364: send diary-llm Telegram through Cabinet

### DIFF
--- a/diary-llm/README.md
+++ b/diary-llm/README.md
@@ -20,7 +20,7 @@ Conversational AI diary for [OpenClaw](https://docs.openclaw.ai): natural Telegr
 
 This will:
 
-1. Create a venv and install `diary-llm`
+1. Create a venv and install `diary-llm` plus local Cabinet (`telegram.target` lives there)
 2. Write `~/.config/diary-llm/config.yaml` from the example (if missing)
 3. Install the workspace skill + link the OpenClaw plugin
 4. Register an `openclaw cron` job for `diary-llm tick`
@@ -50,7 +50,7 @@ See `config.example.yaml`. Important knobs:
 | Key | Purpose |
 | --- | --- |
 | `diary_dir` | Markdown diary root |
-| `telegram.target` | Telegram chat id |
+| Cabinet `telegram.target` | Telegram chat id (`cabinet -p telegram target …`) |
 | `proactive.*` | Cadence + allowed hours |
 | `inactivity_timeout_hours` | Auto-finalize window |
 | `history.*` | How much prior diary context to feed the LLM |

--- a/diary-llm/config.example.yaml
+++ b/diary-llm/config.example.yaml
@@ -4,9 +4,9 @@ diary_dir: /Users/tyler/syncthing/notes/diary
 # conversations_dir defaults to <diary_dir>/conversations
 # state_dir defaults to ~/.local/share/diary-llm
 
-telegram:
-  channel: telegram
-  target: "1234567890"
+# Telegram chat id and send path live in Cabinet (not this file):
+#   cabinet -p telegram target <chat_id>
+#   cabinet --telegram "test"
 
 proactive:
   enabled: true

--- a/diary-llm/pyproject.toml
+++ b/diary-llm/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "PyYAML>=6.0",
+  "cabinet>=1!3.1.0",
 ]
 
 [project.optional-dependencies]

--- a/diary-llm/scripts/install_openclaw.sh
+++ b/diary-llm/scripts/install_openclaw.sh
@@ -13,6 +13,9 @@ python3 -m venv "${VENV}"
 # shellcheck disable=SC1091
 source "${VENV}/bin/activate"
 pip install -U pip
+if [[ -d "${HOME}/git/cabinet" ]]; then
+  pip install -e "${HOME}/git/cabinet"
+fi
 pip install -e "${ROOT}[dev]"
 
 mkdir -p "${HOME}/.local/bin"
@@ -80,12 +83,14 @@ print(cfg.get('tick_cron', '0 */2 * * *'))
 PY
 )"
   TARGET="$(python3 - <<'PY'
-import yaml
-from pathlib import Path
-cfg = yaml.safe_load(Path.home().joinpath('.config/diary-llm/config.yaml').read_text()) or {}
-print((cfg.get('telegram') or {}).get('target') or '8974380881')
+from cabinet import Cabinet
+cab = Cabinet()
+print(cab.get("telegram", "target") or cab.get("telegram", "chat_id") or "")
 PY
 )"
+  if [[ -z "${TARGET}" ]]; then
+    echo "Warning: cabinet telegram.target is unset; cron --to will be empty"
+  fi
 
   openclaw cron add \
     --name "diary-llm-tick" \

--- a/diary-llm/src/diary_llm/cli.py
+++ b/diary-llm/src/diary_llm/cli.py
@@ -108,11 +108,7 @@ def main(argv: list[str] | None = None) -> int:
     cfg = load_config(args.config)
 
     llm = StubLLM() if args.stub_llm else build_llm(cfg.llm)
-    sender = TelegramSender(
-        cfg.telegram,
-        openclaw_bin=cfg.llm.openclaw_bin,
-        dry_run=args.dry_run,
-    )
+    sender = TelegramSender(dry_run=args.dry_run)
     wf = DiaryWorkflow(cfg, llm=llm, sender=sender)
 
     if args.command == "status":

--- a/diary-llm/src/diary_llm/config.py
+++ b/diary-llm/src/diary_llm/config.py
@@ -17,12 +17,6 @@ DEFAULT_CONFIG_PATHS = (
 
 
 @dataclass
-class TelegramConfig:
-    channel: str = "telegram"
-    target: str = ""
-
-
-@dataclass
 class ProactiveConfig:
     enabled: bool = True
     min_days: float = 2.0
@@ -60,7 +54,6 @@ class DiaryConfig:
     diary_dir: Path
     conversations_dir: Path
     state_dir: Path
-    telegram: TelegramConfig = field(default_factory=TelegramConfig)
     proactive: ProactiveConfig = field(default_factory=ProactiveConfig)
     conversation: ConversationConfig = field(default_factory=ConversationConfig)
     inactivity_timeout_hours: float = 3.0
@@ -121,7 +114,6 @@ def load_config(
     )
     state_dir = _expand(raw.get("state_dir") or default_state_dir())
 
-    tg_raw = raw.get("telegram") or {}
     proactive_raw = raw.get("proactive") or {}
     conversation_raw = raw.get("conversation") or {}
     history_raw = raw.get("history") or {}
@@ -131,10 +123,6 @@ def load_config(
         diary_dir=diary_dir,
         conversations_dir=conversations_dir,
         state_dir=state_dir,
-        telegram=TelegramConfig(
-            channel=str(tg_raw.get("channel") or "telegram"),
-            target=str(tg_raw.get("target") or ""),
-        ),
         proactive=ProactiveConfig(
             enabled=bool(proactive_raw.get("enabled", True)),
             min_days=float(proactive_raw.get("min_days", 2)),

--- a/diary-llm/src/diary_llm/telegram.py
+++ b/diary-llm/src/diary_llm/telegram.py
@@ -1,11 +1,9 @@
-"""Telegram delivery via OpenClaw CLI."""
+"""Telegram delivery via Cabinet (OpenClaw / Bot API)."""
 
 from __future__ import annotations
 
-import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
-
-from .config import TelegramConfig
 
 
 @dataclass
@@ -14,17 +12,28 @@ class SendResult:
     output: str = ""
 
 
+def _cabinet_send(message: str) -> bool:
+    from cabinet import telegram as cabinet_telegram
+
+    return bool(cabinet_telegram(message, is_quiet=True))
+
+
 class TelegramSender:
+    """
+    Record and deliver diary Telegram messages.
+
+    Production sends go through ``cabinet.telegram`` so chat id / OpenClaw live
+    in Cabinet. Tests pass ``dry_run=True`` or a fake ``send_fn``.
+    """
+
     def __init__(
         self,
-        cfg: TelegramConfig,
         *,
-        openclaw_bin: str = "openclaw",
         dry_run: bool = False,
+        send_fn: Callable[[str], bool] | None = None,
     ) -> None:
-        self.cfg = cfg
-        self.openclaw_bin = openclaw_bin
         self.dry_run = dry_run
+        self.send_fn = send_fn
         self.sent: list[str] = []
 
     def send(self, message: str) -> SendResult:
@@ -34,28 +43,11 @@ class TelegramSender:
         self.sent.append(message)
         if self.dry_run:
             return SendResult(ok=True, output="dry-run")
-        if not self.cfg.target:
-            return SendResult(ok=False, output="telegram.target is not configured")
-        cmd = [
-            self.openclaw_bin,
-            "message",
-            "send",
-            "--channel",
-            self.cfg.channel,
-            "--target",
-            self.cfg.target,
-            "--message",
-            message,
-        ]
+        fn = self.send_fn or _cabinet_send
         try:
-            proc = subprocess.run(
-                cmd,
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-        except (OSError, subprocess.TimeoutExpired) as exc:
+            ok = fn(message)
+        except Exception as exc:  # noqa: BLE001 - surface to workflow
             return SendResult(ok=False, output=str(exc))
-        out = (proc.stdout or proc.stderr or "").strip()
-        return SendResult(ok=proc.returncode == 0, output=out)
+        if ok:
+            return SendResult(ok=True, output="")
+        return SendResult(ok=False, output="cabinet.telegram failed")

--- a/diary-llm/src/diary_llm/workflow.py
+++ b/diary-llm/src/diary_llm/workflow.py
@@ -68,10 +68,7 @@ class DiaryWorkflow:
         self.store = SessionStore(cfg.active_session_path, cfg.conversations_dir)
         self.llm = llm or build_llm(cfg.llm)
         self.history = history or MarkdownDiaryHistory(cfg.diary_dir)
-        self.sender = sender or TelegramSender(
-            cfg.telegram,
-            openclaw_bin=cfg.llm.openclaw_bin,
-        )
+        self.sender = sender or TelegramSender()
         self.rng = rng or random.Random()
         self.now_fn = now_fn or utc_now
 

--- a/diary-llm/tests/conftest.py
+++ b/diary-llm/tests/conftest.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from diary_llm.config import ConversationConfig, DiaryConfig, HistoryConfig, LLMConfig, ProactiveConfig, TelegramConfig, load_config
+from diary_llm.config import ConversationConfig, DiaryConfig, HistoryConfig, LLMConfig, ProactiveConfig
 from diary_llm.llm import StubLLM
 from diary_llm.telegram import TelegramSender
 from diary_llm.workflow import DiaryWorkflow
@@ -26,7 +26,6 @@ def tmp_cfg(tmp_path: Path) -> DiaryConfig:
         diary_dir=diary_dir,
         conversations_dir=conversations,
         state_dir=state_dir,
-        telegram=TelegramConfig(channel="telegram", target="123"),
         proactive=ProactiveConfig(
             enabled=True,
             min_days=2,
@@ -58,7 +57,7 @@ def fixed_now():
 @pytest.fixture
 def workflow(tmp_cfg: DiaryConfig, fixed_now) -> DiaryWorkflow:
     llm = StubLLM()
-    sender = TelegramSender(tmp_cfg.telegram, dry_run=True)
+    sender = TelegramSender(dry_run=True)
     return DiaryWorkflow(
         tmp_cfg,
         llm=llm,
@@ -77,7 +76,6 @@ def config_file(tmp_path: Path, tmp_cfg: DiaryConfig) -> Path:
                 "diary_dir": str(tmp_cfg.diary_dir),
                 "conversations_dir": str(tmp_cfg.conversations_dir),
                 "state_dir": str(tmp_cfg.state_dir),
-                "telegram": {"channel": "telegram", "target": "123"},
                 "proactive": {
                     "enabled": True,
                     "min_days": 2,

--- a/diary-llm/tests/test_telegram.py
+++ b/diary-llm/tests/test_telegram.py
@@ -1,0 +1,63 @@
+"""Tests for Cabinet-backed TelegramSender."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from diary_llm.telegram import TelegramSender, _cabinet_send
+
+
+def test_dry_run_records_without_calling_send_fn():
+    calls: list[str] = []
+    sender = TelegramSender(dry_run=True, send_fn=lambda m: calls.append(m) or True)
+    result = sender.send("hello")
+    assert result.ok
+    assert result.output == "dry-run"
+    assert sender.sent == ["hello"]
+    assert calls == []
+
+
+def test_empty_message_is_noop():
+    sender = TelegramSender(send_fn=lambda _m: False)
+    result = sender.send("  ")
+    assert result.ok
+    assert sender.sent == []
+
+
+def test_send_fn_success():
+    sender = TelegramSender(send_fn=lambda _m: True)
+    result = sender.send("hi")
+    assert result.ok
+    assert sender.sent == ["hi"]
+
+
+def test_send_fn_failure():
+    sender = TelegramSender(send_fn=lambda _m: False)
+    result = sender.send("hi")
+    assert result.ok is False
+    assert "cabinet.telegram" in result.output
+
+
+def test_send_fn_exception():
+    def boom(_message: str) -> bool:
+        raise RuntimeError("nope")
+
+    sender = TelegramSender(send_fn=boom)
+    result = sender.send("hi")
+    assert result.ok is False
+    assert "nope" in result.output
+
+
+def test_cabinet_send_delegates(monkeypatch):
+    seen: list[tuple[str, bool]] = []
+
+    def fake_telegram(message: str, is_quiet: bool = False) -> bool:
+        seen.append((message, is_quiet))
+        return True
+
+    fake_mod = types.ModuleType("cabinet")
+    fake_mod.telegram = fake_telegram  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "cabinet", fake_mod)
+    assert _cabinet_send("ping") is True
+    assert seen == [("ping", True)]

--- a/diary-llm/tests/test_workflow.py
+++ b/diary-llm/tests/test_workflow.py
@@ -79,7 +79,7 @@ def test_hard_close_even_if_model_keeps_asking(tmp_cfg, fixed_now):
     wf = DiaryWorkflow(
         tmp_cfg,
         llm=ClingyLLM(),
-        sender=TelegramSender(tmp_cfg.telegram, dry_run=True),
+        sender=TelegramSender(dry_run=True),
         rng=__import__("random").Random(0),
         now_fn=fixed_now,
     )


### PR DESCRIPTION
## Summary
- Diary Telegram delivery now calls `cabinet.telegram()` instead of shelling out to OpenClaw itself.
- Chat id comes from Cabinet `telegram.target` (yaml `telegram:` block removed from example config).
- Install script reads the cron `--to` target from Cabinet and installs local Cabinet when present.

Depends on https://github.com/tylerjwoodfin/cabinet/pull/130 (`cabinet>=1!3.1.0`).

## Test plan
- [ ] `cd ~/git/tools/diary-llm && pytest -q`
- [ ] `diary-llm --stub-llm --dry-run status` still works
- [ ] Confirm Cabinet has `telegram.target`, then `diary-llm --stub-llm tick` (or start with `--send`) delivers via Cabinet/OpenClaw


Made with [Cursor](https://cursor.com)